### PR TITLE
Added plugin remove function that signals removal to a plugin

### DIFF
--- a/bluesky/tools/plugin.py
+++ b/bluesky/tools/plugin.py
@@ -155,16 +155,21 @@ def remove(name):
     if preset:
         # Call module reset first to clear plugin state just in case.
         preset()
-    # Call plugin remove for plugins that have one
-    for fun in remove_funs.values():
-        fun()
+
+    # Call plugin remove function before deleting the function from the remove_funs
+    # dictionary to let the plugin know it is about to be removed.
+    premove = remove_funs.pop(name, None)
+    if premove:
+        premove()
+
+    # Remove plugin commands from the BlueSky stack
     descr  = plugin_descriptions.get(name)
     cmds, _ = list(zip(*descr.plugin_stack))
     bs.stack.remove_commands(cmds)
     active_plugins.pop(name)
     preupdate_funs.pop(name)
     update_funs.pop(name)
-    remove_funs.pop(name)
+
     return True, 'Successfully removed plugin {}'.format(name)
 
 def preupdate(simt):

--- a/bluesky/tools/plugin.py
+++ b/bluesky/tools/plugin.py
@@ -109,6 +109,7 @@ def init(mode):
 preupdate_funs = dict()
 update_funs    = dict()
 reset_funs     = dict()
+remove_funs    = dict()
 
 def load(name):
     ''' Load a plugin. '''
@@ -128,12 +129,15 @@ def load(name):
         prefun = config.get('preupdate')
         updfun = config.get('update')
         rstfun = config.get('reset')
+        remfun = config.get('remove')
         if prefun:
             preupdate_funs[name] = [bs.sim.simt + dt, dt, prefun]
         if updfun:
             update_funs[name]    = [bs.sim.simt + dt, dt, updfun]
         if rstfun:
             reset_funs[name]     = rstfun
+        if remfun:
+            remove_funs[name] = remfun
         # Add the plugin's stack functions to the stack
         bs.stack.append_commands(stackfuns)
         # Add the plugin as data parent to the variable explorer
@@ -151,12 +155,17 @@ def remove(name):
     if preset:
         # Call module reset first to clear plugin state just in case.
         preset()
+    # Call plugin remove for plugins that have one
+    for fun in remove_funs.values():
+        fun()
     descr  = plugin_descriptions.get(name)
     cmds, _ = list(zip(*descr.plugin_stack))
     bs.stack.remove_commands(cmds)
     active_plugins.pop(name)
     preupdate_funs.pop(name)
     update_funs.pop(name)
+    remove_funs.pop(name)
+    return True, 'Successfully removed plugin {}'.format(name)
 
 def preupdate(simt):
     ''' Update function executed before traffic update.'''


### PR DESCRIPTION
Currently when using 'PLUGINS REMOVE name' the plugin is only called via plugin.reset(name). This calls its reset() function to clear its state and it is then removed from all plugin management dictionaries. 

However, in some cases this is not sufficient. For example, plugins that define classes inheriting from TrafficArrays will register their instance(s) as child element(s) of the Traffic object. Currently on removal these objects are only called via the plugin.reset() function which does not actually remove the element from the TrafficArrays tree. 

Adding a 'remove' function in the plugins config dictionary solves this problem, because the plugin can now be instructed to delete itself (instead of only resetting its state).

Added bonus: plugin code can now be edited and tested without restaring BlueSky by simply using 'PLUGINS REMOVE name' and 'PLUGINS LOAD name'. 