### PR TITLE
Bugfix: Latitude/longitude bounds

### DIFF
--- a/bluesky/tools/geo.py
+++ b/bluesky/tools/geo.py
@@ -271,18 +271,18 @@ def qdrpos(latd1, lond1, qdr, dist):
              latd2,lond2 (IN DEGREES!)
         Ref for qdrpos: http://www.movable-type.co.uk/scripts/latlong.html """
 
-    r_earth_at_lat = rwgs84(latd1) / nm
+    r_earth_lat = rwgs84(latd1) / nm
 
     # Convert degrees to radians
     lat1 = np.radians(latd1)
     lon1 = np.radians(lond1)
 
     # Calculate new position
-    lat2 = np.arcsin(np.sin(lat1) * np.cos(dist / r_earth_at_lat) \
-                     + np.cos(lat1) * np.sin(dist/r_earth_at_lat) * np.cos(np.radians(qdr)))
+    lat2 = np.arcsin(np.sin(lat1) * np.cos(dist / r_earth_lat) \
+                     + np.cos(lat1) * np.sin(dist/r_earth_lat) * np.cos(np.radians(qdr)))
 
-    lon2 = lon1 + np.arctan2(np.sin(np.radians(qdr)) * np.sin(dist / r_earth_at_lat) * np.cos(lat1),
-                             np.cos(dist / r_earth_at_lat) - np.sin(lat1) * np.sin(lat2))
+    lon2 = lon1 + np.arctan2(np.sin(np.radians(qdr)) * np.sin(dist / r_earth_lat) * np.cos(lat1),
+                             np.cos(dist / r_earth_lat) - np.sin(lat1) * np.sin(lat2))
 
     # Convert back to degrees and normalize longitude to range [-180..180] deg
     latd2 = np.degrees(lat2)

--- a/bluesky/tools/geo.py
+++ b/bluesky/tools/geo.py
@@ -271,18 +271,24 @@ def qdrpos(latd1, lond1, qdr, dist):
              latd2,lond2 (IN DEGREES!)
         Ref for qdrpos: http://www.movable-type.co.uk/scripts/latlong.html """
 
-    # Unit conversion
-    R = rwgs84(latd1)/nm
+    r_earth_at_lat = rwgs84(latd1) / nm
+
+    # Convert degrees to radians
     lat1 = np.radians(latd1)
     lon1 = np.radians(lond1)
 
     # Calculate new position
-    lat2 = np.arcsin(np.sin(lat1)*np.cos(dist/R) +
-              np.cos(lat1)*np.sin(dist/R)*np.cos(np.radians(qdr)))
+    lat2 = np.arcsin(np.sin(lat1) * np.cos(dist / r_earth_at_lat) \
+                     + np.cos(lat1) * np.sin(dist/r_earth_at_lat) * np.cos(np.radians(qdr)))
 
-    lon2 = lon1 + np.arctan2(np.sin(np.radians(qdr))*np.sin(dist/R)*np.cos(lat1),
-                     np.cos(dist/R) - np.sin(lat1)*np.sin(lat2))
-    return np.degrees(lat2), np.degrees(lon2)
+    lon2 = lon1 + np.arctan2(np.sin(np.radians(qdr)) * np.sin(dist / r_earth_at_lat) * np.cos(lat1),
+                             np.cos(dist / r_earth_at_lat) - np.sin(lat1) * np.sin(lat2))
+
+    # Convert back to degrees and normalize longitude to range [-180..180] deg
+    latd2 = np.degrees(lat2)
+    lond2 = (np.degrees(lon2) + 540) % 360 - 180
+
+    return latd2, lond2
 
 
 def kwikdist(lata, lona, latb, lonb):

--- a/bluesky/traffic/traffic.py
+++ b/bluesky/traffic/traffic.py
@@ -469,9 +469,7 @@ class Traffic(TrafficArrays):
     def UpdatePosition(self, simdt):
         # Update position
         self.alt = np.where(self.swaltsel, self.alt + self.vs * simdt, self.pilot.alt)
-        self.lat = self.lat + np.degrees(simdt * self.gsnorth / Rearth)
-        self.coslat = np.cos(np.deg2rad(self.lat))
-        self.lon = self.lon + np.degrees(simdt * self.gseast / self.coslat / Rearth)
+        self.lat, self.lon = geo.qdrpos(self.lat, self.lon, self.trk, self.gs * simdt / 1852.)
         self.distflown += self.gs * simdt
 
     def id2idx(self, acid):


### PR DESCRIPTION
This pull request aims to fix issue where aircraft could fly to latitudes <-90 and >90 degrees and longitudes <-180 and >180 degrees. 

Example scenario with an aircraft heading due north near the north pole. Before, BlueSky happily increases latitude > 90 degrees. After fix the aircraft ends up crossing the pole to a lower latitude (and then bounces back-and-forth across the pole since its heading still remains set at 360, which is probably another issue)

> 0:00:0.0>CRE AC001 B744 89.8,1 360,36000,300
> 0:00:0.0>PAN 89.5,1

Example scenario with aircraft crossing the 180th meridian. Before, BlueSky happily increases/decreases longitude beyond +-180 degrees. After, the aircraft longitudes are in the correct hemisphere after crossing the meridian.
> 0:00:0.0>PAN 0,179.9
> 0:00:0.0>TRAIL ON
> 0:00:0.0>LINE ANTIMERIDIAN,-20,180,20,180
> 0:00:0.0>CRE AC001 B744 1,179.5 090,36000,300
> 0:00:0.0>CRE AC002 B744 -1,-179.5 270,36000,300

There also seems to be separate, but perhaps related issue in drawing aircraft trails when crossing the 180th meridian.

