### PR TITLE
Update geo.py kwikqdrdist_matrix for nonsquare matrices

### DIFF
--- a/bluesky/tools/geo.py
+++ b/bluesky/tools/geo.py
@@ -357,7 +357,7 @@ def kwikqdrdist_matrix(lata, lona, latb, lonb):
     re      = 6371000.  # radius earth [m]
     dlat    = np.radians(latb - lata.T)
     dlon    = np.radians(((lonb - lona.T)+ 180) % 360 - 180)
-    cavelat = np.cos(np.radians(lata + latb.T) * 0.5)
+    cavelat = np.cos(np.radians(latb + lata.T) * 0.5)
 
     dangle  = np.sqrt(np.multiply(dlat, dlat) +
                       np.multiply(np.multiply(dlon, dlon),


### PR DESCRIPTION
In equation for cavelat, "lata + latb.T" was changed to "latb + lata.T", such that it is possible to also have nonsquare matrices as inputs for kwikqdrdist_matrix. The result for kwikqdrdist_matrix with square matrices as inputs is not affected by this change.