### PR TITLE
Path.rglob does not follow symlinks

### DIFF
--- a/bluesky/core/plugin.py
+++ b/bluesky/core/plugin.py
@@ -1,8 +1,9 @@
 """ Implementation of BlueSky's plugin system. """
 import ast
+import glob
+
 from bluesky.stack.stackbase import sender
 from os import path
-from pathlib import Path
 import sys
 import imp
 import bluesky as bs
@@ -90,7 +91,7 @@ class Plugin:
     @classmethod
     def find_plugins(cls, reqtype):
         ''' Create plugin wrapper objects based on source code of potential plug-in files. '''
-        for fname in Path(settings.plugin_path).rglob('*.py'):
+        for fname in glob.glob('{}/**/*.py'.format(settings.plugin_path), recursive=True):
             with open(fname, 'rb') as f:
                 source = f.read()
                 try:


### PR DESCRIPTION
Path.rglob  that was used previously to discover plugins had a bug (https://bugs.python.org/issue33428) that it does not follow symlinks.
So, if in "/plugins/" directory I create a symlink to another directory where I have plugin files, then Path.rglob would just ignore this directory.

I only tested the fix in Linux, I think it should work fine on Mac/Win, but I don't have an opportunity to check that. 