### PR TITLE
Implement reset function in ConflictResolution() class

### DIFF
--- a/bluesky/traffic/asas/resolution.py
+++ b/bluesky/traffic/asas/resolution.py
@@ -39,6 +39,16 @@ class ConflictResolution(Entity, replaceable=True):
             self.alt = np.array([])  # alt provided by the ASAS [m]
             self.vs = np.array([])  # vspeed provided by the ASAS [m/s]
 
+    def reset(self):
+        super().reset()
+        self.swprio = False
+        self.priocode = ''
+        self.resopairs.clear()
+        self.resofach = bs.settings.asas_marh
+        self.resofacv = bs.settings.asas_marv
+        self.resodhrelative = True
+        self.resorrelative  = True
+
     # By default all channels are controlled by self.active,
     # but they can be overloaded with separate variables or functions in a
     # derived ASAS Conflict Resolution class (@property decorator takes away


### PR DESCRIPTION
Currently, settings from a previous simulation are preserved after calling reset. Furthermore, self.resopairs still contains resolution pairs from the last timestep before reset. Although this set is updated the first time self.resumenav (function) is executed, problems can occur when referring to self.resopairs before ASAS is updated. This could be fixed by implementing a reset function in the ConflictResolution() class.