### PR TITLE
function to access plugin objects from anywhere

### DIFF
--- a/bluesky/core/varexplorer.py
+++ b/bluesky/core/varexplorer.py
@@ -40,6 +40,30 @@ def getvarsfromobj(obj):
     except TypeError:
         return None
 
+def access_plugin_object(plugin_name):
+    """
+    Access a BlueSky plugin module by name. This can be used to access
+    the objects in a plugin module.
+
+    Parameters
+    ----------
+    plugin_name : str
+
+    Returns
+    -------
+    plugin module : module
+        The plugin module object.
+    """
+    # first make everything lowercase
+    plugin_name = plugin_name.lower()
+
+    # get the plugin module
+    try:
+        return varlist[plugin_name][0]
+
+    except:
+        bs.scr.echo(f'Plugin {plugin_name} not found')
+        return
 
 def lsvar(varname=''):
     ''' Stack function to list information on simulation variables in the


### PR DESCRIPTION
I made a function to access plugin objects from other plugins to make it easier to communicate between plugins.

If plugin A wants to access Plugin B it can just import this below,

```python
from bluesky.core.varexplorer import access_plugin_object
```

And now to access plugin B, plugin A just needs to do this:

```python
# access a plugin B from plugin A
plugin_B_obj = access_plugin_object('B')
```

