### PR TITLE
working pyqt5 and pyqt6

### DIFF
--- a/bluesky/ui/loadvisuals_txt.py
+++ b/bluesky/ui/loadvisuals_txt.py
@@ -82,8 +82,12 @@ def load_coastline_txt():
 
 # Only try this if BlueSky is started in qtgl gui mode
 if bs.gui_type == 'qtgl':
-    from PyQt6.QtCore import Qt
-    from PyQt6.QtWidgets import QApplication, QProgressDialog
+    try:
+        from PyQt5.QtCore import Qt
+        from PyQt5.QtWidgets import QApplication, QProgressDialog
+    except ImportError:
+        from PyQt6.QtCore import Qt
+        from PyQt6.QtWidgets import QApplication, QProgressDialog
     from bluesky.ui.polytools import PolygonSet, BoundingBox
 
 

--- a/bluesky/ui/qtgl/glhelpers.py
+++ b/bluesky/ui/qtgl/glhelpers.py
@@ -5,7 +5,7 @@ from collections import namedtuple
 from collections import OrderedDict
 
 try:
-    from PyQt5.QtCore import qCritical
+    from PyQt5.QtCore import qCritical, QT_VERSION_STR
     from PyQt5.QtWidgets import QOpenGLWidget
     from PyQt5.QtGui import (QSurfaceFormat, QOpenGLShader, QOpenGLShaderProgram,
                             QOpenGLVertexArrayObject, QOpenGLBuffer,
@@ -15,7 +15,7 @@ try:
 
 
 except ImportError:
-    from PyQt6.QtCore import qCritical
+    from PyQt6.QtCore import qCritical, QT_VERSION_STR
     from PyQt6.QtOpenGLWidgets import QOpenGLWidget
     from PyQt6.QtOpenGL import (QOpenGLShader, QOpenGLShaderProgram,
                          QOpenGLVertexArrayObject, QOpenGLBuffer,
@@ -82,8 +82,11 @@ def init():
             # Use a dummy context to get GL functions
             glprofile = QOpenGLVersionProfile(fmt)
             ctx = QOpenGLContext()
-            function_factory = QOpenGLVersionFunctionsFactory()
-            globals()['gl'] = function_factory.get(glprofile, ctx)
+            if QT_VERSION_STR[0] == '5':
+                globals()['gl'] = ctx.versionFunctions(glprofile)
+            elif QT_VERSION_STR[0] == '6':
+                function_factory = QOpenGLVersionFunctionsFactory()
+                globals()['gl'] = function_factory.get(glprofile, ctx)
             # Check and set OpenGL capabilities
             if not glprofile.hasProfiles():
                 raise RuntimeError(
@@ -119,8 +122,11 @@ def init_glcontext(ctx):
         # The OpenGL functions are provided by the Qt library. Update them from the current context
         fmt = QSurfaceFormat.defaultFormat()
         glprofile = QOpenGLVersionProfile(fmt)
-        function_factory = QOpenGLVersionFunctionsFactory()
-        globals()['gl'] = function_factory.get(glprofile, ctx)
+        if QT_VERSION_STR[0] == '5':
+            globals()['gl'] = ctx.versionFunctions(glprofile)
+        elif QT_VERSION_STR[0] == '6':
+            function_factory = QOpenGLVersionFunctionsFactory()
+            globals()['gl'] = function_factory.get(glprofile, ctx)
     # QtOpenGL doesn't wrap all necessary functions. We can do this manually
 
     # void glGetActiveUniformBlockName(	GLuint program,

--- a/bluesky/ui/qtgl/gui.py
+++ b/bluesky/ui/qtgl/gui.py
@@ -1,8 +1,7 @@
 """ QTGL Gui for BlueSky."""
 try:
     from PyQt5.QtCore import Qt, QEvent, qInstallMessageHandler, \
-        QtWarningMsg, QtCriticalMsg, QtFatalMsg, \
-        QT_VERSION, QT_VERSION_STR
+        QtMsgType, QT_VERSION, QT_VERSION_STR
     from PyQt5.QtWidgets import QApplication, QErrorMessage
     from PyQt5.QtGui import QFont
     


### PR DESCRIPTION
Both `pyqt5` and `pyqt6` work now..

However there is still something I am not sure about in the `UniformBufferObject` class ([line 946](https://github.com/amorfinv/bluesky/blob/e0b5d85e4392a47a4ee0b9e4606b313dbd7b668d/bluesky/ui/qtgl/glhelpers.py#L946)).

I get this message when closing bluesky (both `pyqt5` and `pyqt6`) if I use `super().__init__(QOpenGLBuffer.Type.VertexBuffer)` in the constructor

```
Qt gui warning: QOpenGLVertexArrayObject::destroy() failed to restore current context
```

If I use `super().__init__(gl.GL_UNIFORM_BUFFER)` instead, then only the `pyqt5` version works.