### PR TITLE
Fix casmach threshold in route(gui)

### DIFF
--- a/bluesky/simulation/screenio.py
+++ b/bluesky/simulation/screenio.py
@@ -5,7 +5,7 @@ import numpy as np
 # Local imports
 import bluesky as bs
 from bluesky import stack
-from bluesky.tools import areafilter
+from bluesky.tools import areafilter, aero
 from bluesky.core.walltime import Timer
 
 class ScreenIO:
@@ -268,6 +268,9 @@ class ScreenIO:
 
         # Transition level as defined in traf
         data['translvl']   = bs.traf.translvl
+
+        # Send casmachthr for route visualization
+        data['casmachthr']    = aero.casmach_thr
 
         # ASAS resolutions for visualization. Only send when evaluated
         data['asastas']  = bs.traf.cr.tas

--- a/bluesky/ui/qtgl/gltraffic.py
+++ b/bluesky/ui/qtgl/gltraffic.py
@@ -228,7 +228,7 @@ class Traffic(glh.RenderObject, layer=100):
                     # Speed
                     if spd < 0:
                         txt += "--- "
-                    elif spd > 2.0:
+                    elif spd > actdata.casmachthr:
                         txt += "%03d" % int(round(spd / kts))
                     else:
                         txt += f"M{spd:.2f}" # Mach number
@@ -260,6 +260,7 @@ class Traffic(glh.RenderObject, layer=100):
             data.rpz = data.rpz[idx]
         naircraft = len(data.lat)
         actdata.translvl = data.translvl
+        actdata.casmachthr = data.casmachthr
         # self.asas_vmin = data.vmin # TODO: array should be attribute not uniform
         # self.asas_vmax = data.vmax
 


### PR DESCRIPTION
The ```casmach_thr``` value is currently ignored in the gui when it appears on the route constraints

<img width="918" alt="image" src="https://user-images.githubusercontent.com/78442543/179035031-e7cdfe33-9a00-444a-9513-07c2eb074c17.png">


With this fix, the correct speed constraint appears in the waypoint.

<img width="913" alt="image" src="https://user-images.githubusercontent.com/78442543/179035389-246d8cf6-b1e5-4cb5-9700-feae53522a0d.png">
