### PR TITLE
create config when it does not exist

### DIFF
--- a/bluesky/settings.py
+++ b/bluesky/settings.py
@@ -47,6 +47,13 @@ def init(cfgfile=''):
 
     if not cfgfile:
         cfgfile = _basepath / 'settings.cfg'
+
+        # check if config file exists
+        if not cfgfile.is_file():
+            # If not, create a default config file
+            print(f'Creating default config file "{cfgfile}"')
+            shutil.copyfile(_srcpath / 'data/default.cfg', cfgfile)
+  
     print(f'Reading config from {cfgfile}')
     exec(compile(open(cfgfile).read().replace('\\', '/'), cfgfile, 'exec'), globals())
 


### PR DESCRIPTION
Fixing #404 .

In latest ```settings.py``` bluesky would only create a ```settings.cfg``` file if it was downloaded as a package. This meant that anyone that used ```git clone``` would not be able to create a ```settings.cfg```.

I tested on mac mini so unsure about others.

-Andres