### PR TITLE
populate directories when they do not exist

### DIFF
--- a/bluesky/settings.py
+++ b/bluesky/settings.py
@@ -60,6 +60,12 @@ def init(cfgfile=''):
     # Store name of config file
     globals()['_cfgfile'] = cfgfile
 
+    # populate some directories in case they don't exist if using from source 
+    for d in ('output', 'data/cache'):
+        if not (_basepath / d).is_dir():
+            print(f'Creating directory "{_basepath / d}"')
+            (_basepath / d).mkdir(parents=True, exist_ok=True)
+
     return True
 
 


### PR DESCRIPTION
Per #404 BlueSky currently does not populate some directories if using source. Now it should check if they exist and create if necessary.

I am not sure if this is where the code should go where it is or if there should be a function. Since it is not so many lines I guess it can go where it is.

-Andres