### PR TITLE
fix positional arguments in qtfiledialog

### DIFF
--- a/bluesky/ui/qtgl/mainwindow.py
+++ b/bluesky/ui/qtgl/mainwindow.py
@@ -384,9 +384,9 @@ class MainWindow(QMainWindow):
         else:
             scenpath = bs.settings.resolve_path(bs.settings.scenario_path).as_posix()
             if platform.system().lower() == 'darwin':
-                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', filter='*.scn')
+                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', initialFilter='*.scn')
             else:
-                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', options=QFileDialog.DontUseNativeDialog, filter='*.scn')
+                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', options=QFileDialog.DontUseNativeDialog, initialFilter='*.scn')
             fname = response[0] if isinstance(response, tuple) else response
 
         # Send IC command to stack with filename if selected, else do nothing

--- a/bluesky/ui/qtgl/mainwindow.py
+++ b/bluesky/ui/qtgl/mainwindow.py
@@ -384,9 +384,9 @@ class MainWindow(QMainWindow):
         else:
             scenpath = bs.settings.resolve_path(bs.settings.scenario_path).as_posix()
             if platform.system().lower() == 'darwin':
-                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', initialFilter='*.scn')
+                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)')
             else:
-                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', options=QFileDialog.DontUseNativeDialog, initialFilter='*.scn')
+                response = QFileDialog.getOpenFileName(self, 'Open file', scenpath, 'Scenario files (*.scn)', options=QFileDialog.DontUseNativeDialog)
             fname = response[0] if isinstance(response, tuple) else response
 
         # Send IC command to stack with filename if selected, else do nothing


### PR DESCRIPTION
Fix bug in ```QFileDialog.getOpenFileName``` introduced in commit 8a3c5e36 which was reported by @DRKWang in #405 .

The issue arose from trying to resolve conflicting keyword and positional arguments. In the ```pyqt``` [documentation](https://www.riverbankcomputing.com/static/Docs/PyQt5/api/qtwidgets/qfiledialog.html?highlight=qfiledialog#QFileDialog) the fourth argument is reserved for ```filter```. Meanwhile, in the code there are four positional arguments so ```filter``` is set to ```'Scenario files (*.scn)'```. This clashes with the keyword argument ```filter='*.scn'```. I am not sure what the intention is but there is another filter argument called ```initialFilter``` so I just changed it to be ```initialFilter='*.scn'```. The ```pyqt``` documentation is a bit lacking so it is not clear.

```python
getOpenFileName(parent: QWidget = None, caption: str = '', directory: str = '', filter: str = '', initialFilter: str = '', options:               │
│ Union[QFileDialog.Options, QFileDialog.Option] = 0) -> Tuple[str, str]
```

Note that this was only tested for the case when ```platform.system().lower() == 'darwin'```. I made the same change inside the ```else``` statement but did not test.

-Andres