### PR TITLE
Patch tiledmap

### DIFF
--- a/bluesky/ui/qtgl/tiledtexture.py
+++ b/bluesky/ui/qtgl/tiledtexture.py
@@ -2,19 +2,21 @@
 import traceback
 import math
 import weakref
+import os
 from collections import OrderedDict
 from urllib.request import urlopen
 from urllib.error import URLError
 import numpy as np
+import gzip
 
 try:
     from PyQt5.Qt import Qt
     from PyQt5.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal, pyqtSlot, QT_VERSION_STR
-    from PyQt5.QtGui import QImage
+    from PyQt5.QtGui import QImage, qRgba
 except ImportError:
     from PyQt6.QtCore import Qt
     from PyQt6.QtCore import QObject, QRunnable, QThreadPool, pyqtSignal, pyqtSlot, QT_VERSION_STR
-    from PyQt6.QtGui import QImage
+    from PyQt6.QtGui import QImage, qRgba
 
 import bluesky as bs
 from bluesky.core import Signal
@@ -58,6 +60,7 @@ class Tile:
         self.idxx = idxx
         self.idxy = idxy
         self.ext = source[source.rfind('.'):]
+        self.ext = '.' + bs.settings.tile_sources[source]['source'][0].split('.')[-1]
 
         self.image = None
         # For the image data, check cache path first
@@ -72,11 +75,24 @@ class Tile:
                 try:
                     url_request = urlopen(url.format(
                         zoom=zoom, x=tilex, y=tiley))
-                    data = url_request.read()
-                    self.image = QImage.fromData(
-                        data).convertToFormat(QImage.Format.Format_ARGB32)
-                    with open(fname, 'wb') as fout:
-                        fout.write(data)
+                    
+                    if url_request.status == 204:
+                        # if no content load a blank tile
+                        self.image = QImage(256, 256, QImage.Format.Format_ARGB32)
+                        self.image.fill(qRgba(255,255,255,0))
+
+                    else:
+                        data = url_request.read()
+
+                        if url_request.headers['Content-Encoding'] == 'gzip':
+                            # There is a chance that data may come as a gzip so decompress
+                            data = gzip.decompress(data)
+                                        
+                        self.image = QImage.fromData(
+                            data).convertToFormat(QImage.Format.Format_ARGB32)
+
+                        with open(fname, 'wb') as fout:
+                            fout.write(data)
                     break
                 except URLError as e:
                     print(f'Error loading {url.format(zoom=zoom, x=tilex, y=tiley)}:')

--- a/bluesky/ui/qtgl/tiledtexture.py
+++ b/bluesky/ui/qtgl/tiledtexture.py
@@ -2,7 +2,6 @@
 import traceback
 import math
 import weakref
-import os
 from collections import OrderedDict
 from urllib.request import urlopen
 from urllib.error import URLError


### PR DESCRIPTION
Made some updates to the tiledmap.

In [line 62](https://github.com/amorfinv/bluesky/blob/patch-tiledmap/bluesky/ui/qtgl/tiledtexture.py#L62) of ```tiledtexture.py``` the  file extension of the tiles is written as

```python
self.ext = source[source.rfind('.'):]
```
However this ends up being the last letter of the ```tilesource``` name. I modified it so that it looks at the url.

The other change is in the tile request.

```python
for url in bs.settings.tile_sources[source]['source']:
    try:
        url_request = urlopen(url.format(
            zoom=zoom, x=tilex, y=tiley))
        
        if url_request.status == 204:
            # if no content load a blank tile
            self.image = QImage(256, 256, QImage.Format.Format_ARGB32)
            self.image.fill(qRgba(255,255,255,0))

        else:
            data = url_request.read()

            if url_request.headers['Content-Encoding'] == 'gzip':
                # There is a chance that data may come as a gzip so decompress
                data = gzip.decompress(data)
                            
            self.image = QImage.fromData(
                data).convertToFormat(QImage.Format.Format_ARGB32)

            with open(fname, 'wb') as fout:
                fout.write(data)
        break
    except URLError as e:
        print(f'Error loading {url.format(zoom=zoom, x=tilex, y=tiley)}:')
        print(traceback.format_exc())
```
 There are cases when there is no content outside of a desired area from a custom tile source. For example, here I have a population density map of europe that I generated tiles for with QGIS.
<img width="919" alt="image" src="https://user-images.githubusercontent.com/78442543/187138943-da4a269f-ade5-46b4-b68c-0c662a19ec24.png">

In the case, where I have no data from tile serve the url request returns a status of 204 which means no data. 


The last request has to do with the url encoding. I ran across some cases where the tile request returns a compressed image instead of the raw image. So I added the  ```url_request.headers['Content-Encoding'] == 'gzip'```.  However, I don't think this is very robust as it may not be a gzip but some other encoding.

The other option would be to use the ```requests``` [library](https://requests.readthedocs.io/en/latest/). This allows you to set a ```stream=True``` argument in your requests so that the data comes as is and is not compressed. However, this adds another dependency to ```bluesky```.

This new code was tested with mac in pyqt5 and pyqt6.