### PR TITLE
[BUG]patch zoom with ctrl + wheel

### DIFF
--- a/bluesky/ui/qtgl/radarwidget.py
+++ b/bluesky/ui/qtgl/radarwidget.py
@@ -278,7 +278,7 @@ class RadarWidget(glh.RenderWidget):
         if event.type() == QEvent.Type.Wheel:
             # For mice we zoom with control/command and the scrolwheel
             if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
-                origin = (event.pos().x(), event.pos().y())
+                origin = (event.position().x(), event.position().y())
                 zoom = 1.0
                 try:
                     if event.pixelDelta():


### PR DESCRIPTION
There is a bug in which zooming in with ctrl + mouse wheel does not work on qt6.

need to change ```event.pos().x()``` to ```event.position().x()```. 

API is a bit strange because in some places ```event.pos()`` works.

I tested on pyqt6 version 6.4 and pyqt5 version 5.15