### PR TITLE
Update traffic.py: Fix the calculation of turnrate

### DIFF
--- a/bluesky/traffic/traffic.py
+++ b/bluesky/traffic/traffic.py
@@ -449,8 +449,8 @@ class Traffic(Entity):
         # tan phi = a centrigugal/a grav = omega^2 * R / g = omega * V /g
         # => omega = (g tan phi)/V
         turnrate = np.degrees(g0 * np.tan(np.where(self.ap.turnphi>self.eps*self.eps,
-                                                   self.ap.turnphi,self.ap.bankdef) \
-                                          / np.maximum(self.tas, self.eps)))
+                                                   self.ap.turnphi,self.ap.bankdef)) \
+                                          / np.maximum(self.tas, self.eps))
         delhdg = (self.aporasas.hdg - self.hdg + 180) % 360 - 180  # [deg]
         self.swhdgsel = np.abs(delhdg) > np.abs(bs.sim.simdt * turnrate)
 


### PR DESCRIPTION
Fixed a bug about the calculation of turnrate, where the original code did not match the calculation formula, resulting in an incorrect calculation of turn rate.