### PR TITLE
Fix turn rate calculation in traffic update loop.

### DIFF
--- a/bluesky/traffic/traffic.py
+++ b/bluesky/traffic/traffic.py
@@ -449,8 +449,8 @@ class Traffic(Entity):
         # tan phi = a centrigugal/a grav = omega^2 * R / g = omega * V /g
         # => omega = (g tan phi)/V
         turnrate = np.degrees(g0 * np.tan(np.where(self.ap.turnphi>self.eps*self.eps,
-                                                   self.ap.turnphi,self.ap.bankdef) \
-                                          / np.maximum(self.tas, self.eps)))
+                                                   self.ap.turnphi,self.ap.bankdef)) \
+                                          / np.maximum(self.tas, self.eps))
         delhdg = (self.aporasas.hdg - self.hdg + 180) % 360 - 180  # [deg]
         self.swhdgsel = np.abs(delhdg) > np.abs(bs.sim.simdt * turnrate)
 


### PR DESCRIPTION
I think the turn rate calculation in the main traffic update loop has a misplaced parenthesis. 

The calculation is currently:
omega = g0 * tan(phi / V)

When I think it should be:
omega = g0 * tan(phi) / V