### PR TITLE
Fix for short commands being sometimes skipped.

### DIFF
--- a/bluesky/stack/simstack.py
+++ b/bluesky/stack/simstack.py
@@ -149,7 +149,7 @@ def readscn(fname):
         for line in fscen:
             line = line.strip()
             # Skip emtpy lines and comments
-            if len(line) < 12 or line[0] == "#":
+            if len(line) < 10 or line[0] == "#":
                 continue
             line = prevline + line
 


### PR DESCRIPTION
The scenario file parser would consider a line is empty (or too short to be a command) if its length was shorter than 12. An example of a valid command that would be skipped in this situation is 00:00:01>FF , which has a length of 11.

As the length of the timestamp needs to be at least 9 (including the > symbol), the parser should check whether the length of a line is smaller than 10.