### PR TITLE
Restore Python <3.9 compatibility

### DIFF
--- a/bluesky/stack/cmdparser.py
+++ b/bluesky/stack/cmdparser.py
@@ -1,6 +1,7 @@
 ''' Stack Command implementation. '''
 import inspect
 import sys, os
+from typing import Dict
 from bluesky.stack.argparser import Parameter, getnextarg, ArgumentError
 
 
@@ -8,7 +9,7 @@ class Command:
     ''' Stack command object. '''
 
     # Dictionary with all command objects
-    cmddict: dict[str, 'Command'] = dict()
+    cmddict: Dict[str, 'Command'] = dict()
 
     @classmethod
     def addcommand(cls, func, parent=None, name='', **kwargs):


### PR DESCRIPTION
https://github.com/TUDelft-CNS-ATM/bluesky/commit/dbaf8ad9c4f9ac18de54bb6edd0b1e46b5aca503 breaks compatibility for Python <3.9 by using annotation features only available in [PEP 593](https://peps.python.org/pep-0593/).

Sadly, the aforementioned commit is already included in the most recent release, `2023.11.22`. Thus, I'd urge to merge this PR and create a new release that really is compatible with 3.7 and 3.8 (as defined in [`setup.py`](https://github.com/TUDelft-CNS-ATM/bluesky/blob/2023.11.22/setup.py#L57-L58)).