### PR TITLE
strip inline comments before processing line

### DIFF
--- a/bluesky/stack/simstack.py
+++ b/bluesky/stack/simstack.py
@@ -161,6 +161,8 @@ def readscn(fname):
 
             # Try reading timestamp and command
             try:
+                line = line.split("#")[0].strip()
+
                 icmdline = line.index(">")
                 tstamp = line[:icmdline]
                 ttxt = tstamp.strip().split(":")


### PR DESCRIPTION
Som scenario files make use of inline comments that are appended to the actual command, for instance:

https://github.com/TUDelft-CNS-ATM/bluesky/blob/849d76fd44880f8d17a69aefa0bd37208f2b2fbb/scenario/LNAV_VNAV/0-VNAV-Landing.SCN#L15

These have been treated as command arguments, so far, leading to an error about unexpected number of parameters.