### PR TITLE
Improve usability of command prompt

### DIFF
--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -169,6 +169,17 @@ class Console(QWidget):
                 self.lineEdit.cursor_word_left()
             elif event.key() == Qt.Key.Key_Right:
                 self.lineEdit.cursor_word_right()
+            elif event.key() == Qt.Key.Key_V:
+                pos = self.lineEdit.cursor_pos()
+                clipboardText = QApplication.clipboard().text()
+                newcmd = newcmd[:pos] + clipboardText + newcmd[pos:]
+                cursorpos = pos + len(clipboardText)
+            elif event.key() == Qt.Key.Key_X:
+                QApplication.clipboard().setText(self.command_line)
+                newcmd = ""
+                cursorpos = 0
+            elif event.key() == Qt.Key.Key_C:
+                QApplication.clipboard().setText(self.command_line)
         elif event.key() >= Qt.Key.Key_Space and event.key() <= Qt.Key.Key_AsciiTilde:
             pos = self.lineEdit.cursor_pos()
             newcmd = newcmd[:pos] + event.text() + newcmd[pos:]

--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -164,7 +164,12 @@ class Console(QWidget):
 
         newcmd = self.command_line
         cursorpos = None
-        if event.key() >= Qt.Key.Key_Space and event.key() <= Qt.Key.Key_AsciiTilde:
+        if event.modifiers() & Qt.KeyboardModifier.ControlModifier:
+            if event.key() == Qt.Key.Key_Left:
+                self.lineEdit.cursor_word_left()
+            elif event.key() == Qt.Key.Key_Right:
+                self.lineEdit.cursor_word_right()
+        elif event.key() >= Qt.Key.Key_Space and event.key() <= Qt.Key.Key_AsciiTilde:
             pos = self.lineEdit.cursor_pos()
             newcmd = newcmd[:pos] + event.text() + newcmd[pos:]
             # Update the cursor position with the length of the added text
@@ -199,10 +204,8 @@ class Console(QWidget):
                         newcmd = self.command_mem
                     else:
                         newcmd = self.command_history[-self.history_pos]
-
             elif event.key() == Qt.Key.Key_Left:
                 self.lineEdit.cursor_left()
-
             elif event.key() == Qt.Key.Key_Right:
                 self.lineEdit.cursor_right()
             elif event.key() == Qt.Key.Key_Home:
@@ -287,6 +290,27 @@ class Cmdline(QTextEdit):
         cursor = self.textCursor()
         cursor.setPosition(len(self.cmdline) + 2)
         self.setTextCursor(cursor)
+
+    def cursor_word_left(self):
+        cursor = self.textCursor()
+        pos = cursor.position() - 2
+        while pos > 0 and self.cmdline[pos - 1] == ' ':
+            pos -= 1 # skip initial spaces
+        while pos > 0 and self.cmdline[pos - 1] != ' ':
+            pos -= 1
+        cursor.setPosition(pos + 2)
+        self.setTextCursor(cursor)
+
+    def cursor_word_right(self):
+        cursor = self.textCursor()
+        pos = cursor.position() - 2
+        while pos < len(self.cmdline) and self.cmdline[pos] == ' ':
+            pos += 1 # skip initial spaces
+        while pos < len(self.cmdline) and self.cmdline[pos] != ' ':
+            pos += 1
+        cursor.setPosition(pos + 2)
+        self.setTextCursor(cursor)
+
 
 class Stackwin(QTextEdit):
     ''' Wrapper class for the stack output textbox. '''

--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -172,6 +172,11 @@ class Console(QWidget):
             pos = self.lineEdit.cursor_pos()
             newcmd = newcmd[:pos - 1] + newcmd[pos:]
             cursorpos = pos - 1
+        elif event.key() == Qt.Key.Key_Delete:
+            pos = self.lineEdit.cursor_pos()
+            if pos < len(newcmd):
+                newcmd = newcmd[:pos] + newcmd[pos + 1:]
+                cursorpos = pos
         elif event.key() == Qt.Key.Key_Tab:
             if newcmd:
                 newcmd, displaytext = autocomplete.complete(newcmd)

--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -50,7 +50,7 @@ def process_cmdline(cmdlines):
 
 
 class Console(QWidget):
-    lineEdit: QTextEdit = None
+    lineEdit: 'Cmdline' = None
     stackText: QTextEdit = None
     _instance = None
 
@@ -182,7 +182,7 @@ class Console(QWidget):
                 newcmd, displaytext = autocomplete.complete(newcmd)
                 if displaytext:
                     self.echo(displaytext)
-        elif not event.modifiers() & (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier | 
+        elif not event.modifiers() & (Qt.KeyboardModifier.ControlModifier | Qt.KeyboardModifier.ShiftModifier |
                                         Qt.KeyboardModifier.AltModifier | Qt.KeyboardModifier.MetaModifier):
             if event.key() == Qt.Key.Key_Up:
                 if self.history_pos == 0:
@@ -204,6 +204,10 @@ class Console(QWidget):
 
             elif event.key() == Qt.Key.Key_Right:
                 self.lineEdit.cursor_right()
+            elif event.key() == Qt.Key.Key_Home:
+                self.lineEdit.cursor_home()
+            elif event.key() == Qt.Key.Key_End:
+                self.lineEdit.cursor_end()
             else:
                 # Remaining keys are things like sole modifier keys, and function keys
                 super().keyPressEvent(event)
@@ -269,6 +273,15 @@ class Cmdline(QTextEdit):
         cursor.setPosition(min(len(self.cmdline) + 2, cursor.position() + 1))
         self.setTextCursor(cursor)
 
+    def cursor_home(self):
+        cursor = self.textCursor()
+        cursor.setPosition(2)
+        self.setTextCursor(cursor)
+
+    def cursor_end(self):
+        cursor = self.textCursor()
+        cursor.setPosition(len(self.cmdline) + 2)
+        self.setTextCursor(cursor)
 
 class Stackwin(QTextEdit):
     ''' Wrapper class for the stack output textbox. '''

--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -242,7 +242,9 @@ class Cmdline(QTextEdit):
                      hints + '</font>')
         self.cmdline = cmdline
         cursor = self.textCursor()
-        cursor.setPosition((cursorpos or len(cmdline)) + 2)
+        if cursorpos is None:
+            cursorpos = len(cmdline)
+        cursor.setPosition(cursorpos + 2)
         self.setTextCursor(cursor)
         # TODO: word objects with possible list of checker functions?
 

--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -14,6 +14,7 @@ from bluesky.network.sharedstate import ActData, get
 from bluesky.ui.qtgl import autocomplete
 from bluesky.ui.radarclick import radarclick
 
+import html
 
 cmdline_stacked = Signal('cmdline_stacked')
 
@@ -247,8 +248,12 @@ class Cmdline(QTextEdit):
 
     def set_cmdline(self, cmdline, hints='', cursorpos=None):
         ''' Set the command line with possible hints. '''
-        self.setHtml('>>' + cmdline + '<font color="#aaaaaa">' +
-                     hints + '</font>')
+        self.setHtml('>>' +
+                    html.escape(cmdline).replace(' ', '&nbsp;') +
+                    '<font color="#aaaaaa">' +
+                    html.escape(hints).replace(' ', '&nbsp;') +
+                    '</font>'
+        )
         self.cmdline = cmdline
         cursor = self.textCursor()
         if cursorpos is None:


### PR DESCRIPTION
I implemented some improvements that fix buggy behavior of the command line prompt (try to insert multiple spaces in between two existing characters and you will see, what I mean).

Furthermore, I added some usability features like copy/paste, word-level navigation, and use of the delete key.

I hope that it is OK to include everything in one PR. Otherwise, I am happy to split it into smaller chunks.

One point that could be debatable is the implementation of CTRL+C. Since there is no text selection feature, one might not expect to copy the full command. Someone may expect classic command line behavior like cancelling (deleting) the current command. Currently, I implemented this in the CTRL+X handler, which copies the current command line to clipboard and clears the prompt line.