### PR TITLE
fix type of workdir in pathfinder

### DIFF
--- a/bluesky/pathfinder.py
+++ b/bluesky/pathfinder.py
@@ -78,7 +78,7 @@ class ResourcePath(MultiplexedPath):
         paths = []
         if not descendants:
             return self
-        
+
         for path in (p.joinpath(*descendants) for p in self._paths):
             if path.exists():
                 if path.is_dir():
@@ -91,13 +91,13 @@ class ResourcePath(MultiplexedPath):
         # if it does not exist, construct it with the first path
         return ResourcePath(*paths) if len(paths) > 1 else \
             paths[0] if len(paths) == 1 else self._paths[0].joinpath(*descendants)
-    
+
     __truediv__ = joinpath
 
 
 def resource(*descendants):
     ''' Get a path pointing to a BlueSky resource.
-    
+
         Arguments:
         - descendants: Zero or more path-like objects (Path or str)
 
@@ -133,7 +133,7 @@ def init(workdir=None):
                 print(f'Creating BlueSky base directory "{workdir.absolute()}"')
                 workdir.mkdir()
 
-    elif not Path(workdir).exists():
+    elif not (workdir := Path(workdir)).exists():
         print(f"Specified working directory {workdir} doesn't exist!")
 
     # Ensure existence of scenario, plugins, output, and cache directories


### PR DESCRIPTION
When providing the workdir command line argument, the current implementation fails with the following error:
```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/BlueSky.py", line 9, in <module>
    sys.exit(main())
             ^^^^^^
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/__main__.py", line 35, in main
    bs.init(**args)
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/__init__.py", line 71, in init
    pathfinder.init(workdir)
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/pathfinder.py", line 140, in init
    for subdir in map(workdir.joinpath, ('scenario', 'plugins', 'output', 'cache')):
                      ^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'joinpath'
```

This PR fixes the type of the workdir argument to be a `Path` object.