### PR TITLE
fix implicit conversion to bool in areafilter

### DIFF
--- a/bluesky/tools/areafilter.py
+++ b/bluesky/tools/areafilter.py
@@ -72,7 +72,7 @@ def defineArea(name, shape, coordinates, top=1e9, bottom=-1e9):
         else:
             return True, 'Currently defined shapes:\n' + \
                 ', '.join(basic_shapes)
-    if not coordinates:
+    if coordinates is None:
         if name in basic_shapes:
             return True, str(basic_shapes[name])
         else:


### PR DESCRIPTION
This PR fixes a bug in the current implementation of `defineArea`, which fails due to an implicit conversion to bool.

These commands
```
PLUGIN ILSGATE
ILSGATE EDDM/RW08R
```
lead to
```
Traceback (most recent call last):
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/stack/simstack.py", line 73, in process
    success, echotext = cmdobj(argstring)
                        ^^^^^^^^^^^^^^^^^
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/stack/cmdparser.py", line 91, in __call__
    ret = self.callback(*args)
          ^^^^^^^^^^^^^^^^^^^^
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/core/funcobject.py", line 32, in __call__
    return self.callback(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/plugins/ilsgate.py", line 90, in ilsgate
    areafilter.defineArea('ILS' + rwyname, 'POLYALT', coordinates, top=4000*ft)
  File "/home/stanley/Documents/s-aman/code/atc_gym/lib/bluesky_simulator/bluesky/tools/areafilter.py", line 75, in defineArea
    if not coordinates:
           ^^^^^^^^^^^
ValueError: The truth value of an array with more than one element is ambiguous. Use a.any() or a.all()
```