### PR TITLE
set workdir for nodes when starting via Server object

### DIFF
--- a/bluesky/__init__.py
+++ b/bluesky/__init__.py
@@ -37,7 +37,7 @@ def init(mode='sim', configfile=None, scenfile=None, discoverable=False,
         - mode: Running mode of this bluesky process [sim/client/server]
         - configfile: Load a different configuration file [filename]
         - scenfile: Start with a running scenario [filename]
-        - discoverable: Make server discoverable through UDP (only relevant 
+        - discoverable: Make server discoverable through UDP (only relevant
           when this process is running a server) [True/False]
         - gui: Gui type (only when mode is client or server) [qtgl/pygame/console]
         - detached: Run with or without networking (only when mode is sim) [True/False]
@@ -93,7 +93,7 @@ def init(mode='sim', configfile=None, scenfile=None, discoverable=False,
     # If mode is server-gui or server-headless start the networking server
     if mode == 'server':
         from bluesky.network.server import Server
-        server = Server(discoverable, configfile, scenfile)
+        server = Server(discoverable, configfile, scenfile, workdir)
 
     # The remaining objects are only instantiated in the sim nodes
     if mode == 'sim':

--- a/bluesky/network/server.py
+++ b/bluesky/network/server.py
@@ -31,7 +31,7 @@ def split_scenarios(scentime, scencmd):
 
 class Server(Thread):
     ''' Implementation of the BlueSky simulation server. '''
-    def __init__(self, discovery, altconfig=None, startscn=None):
+    def __init__(self, discovery, altconfig=None, startscn=None, workdir=None):
         super().__init__()
         self.spawned_processes = dict()
         self.running = True
@@ -42,8 +42,9 @@ class Server(Thread):
         self.sim_nodes = set()
         self.all_nodes = set()
         self.avail_nodes = set()
-        
+
         # Information to pass on to spawned nodes
+        self.workdir = workdir
         self.altconfig = altconfig
         self.startscn = startscn
 
@@ -81,6 +82,8 @@ class Server(Thread):
             args = [sys.executable, '-m', 'bluesky', '--sim', '--groupid', bin2hex(newid)]
             if self.altconfig:
                 args.extend(['--configfile', self.altconfig])
+            if self.workdir:
+                args.extend(['--workdir', self.workdir])
             if startscn:
                 args.extend(['--scenfile', startscn])
             self.spawned_processes[newid] = Popen(args)


### PR DESCRIPTION
When starting BlueSky with the `--workdir` argument, it is not passed to the simulation nodes. Therefore, it is impossible to, for instance, load plugins from the working directory. Furthermore, while the server creates plugin, scenario, cache, and output inside the working directory, the nodes operate on the "~/bluesky" directory. 

This PR might only work after #577 has been merged. Otherwise the `--workdir` argument is not working as expected.