### PR TITLE
fix old turnspeed check

### DIFF
--- a/bluesky/traffic/autopilot.py
+++ b/bluesky/traffic/autopilot.py
@@ -249,6 +249,7 @@ class Autopilot(Entity, replaceable=True):
                                        turnrad,turnspd,turnhdgr, flyturn, flyby)  # update turn distance for VNAV
 
             # Get flyturn switches and data
+            bs.traf.actwp.oldturnspd[i]  = bs.traf.actwp.turnspd[i] # old turnspd, turning by this waypoint
             bs.traf.actwp.flyturn[i]      = flyturn
             bs.traf.actwp.turnrad[i]      = turnrad
             bs.traf.actwp.turnspd[i]      = turnspd
@@ -262,7 +263,6 @@ class Autopilot(Entity, replaceable=True):
             bs.traf.actwp.turntonextwp[i]   = False
 
             # Keep both turning speeds: turn to leg and turn from leg
-            bs.traf.actwp.oldturnspd[i]  = bs.traf.actwp.turnspd[i] # old turnspd, turning by this waypoint
             if bs.traf.actwp.flyturn[i]:
                 bs.traf.actwp.turnspd[i] = turnspd                  # new turnspd, turning by next waypoint
             else:


### PR DESCRIPTION
Hello, I have made some small changes to the autopilot. 

The issue is that the old turn speed does not actually get updated inside ```wppassingcheck()```. 

Currently, line 254 assigns the new turn speed to the active waypoint.

```python
bs.traf.actwp.turnspd[i] = turnspd
```
This means that the old turn speed traffic array actually receives the new turn speed in line 265.

```python
bs.traf.actwp.oldturnspd[i]  = bs.traf.actwp.turnspd[i] # old turnspd, turning by this waypoint
```

Therefore, the check of line 438 inside autopilot ```update()``` has the wrong information about the old turn speed

```python
       bs.traf.selspd = np.where(np.logical_and(inoldturn*(bs.traf.actwp.oldturnspd>0.)*bs.traf.swvnavspd*bs.traf.swvnav*bs.traf.swlnav,
                                    np.logical_not(useturnspd)),
                                  bs.traf.actwp.oldturnspd,bs.traf.selspd)
```

This means that there can be some unexpected speed changes after clearing a waypoint and while the aircraft has not finished the turn.

My suggested fix simply assigns the old turn speed before it gets updated. 

Use this scenario and observe how the aircraft behaves around the ARTIP waypoint. The fix should make the aircraft keep its speed.

```
00:00:00.00>PAN ARTIP
00:00:00.00>ZOOM 2
00:00:00.00>SWRAD GEO
00:00:00.00>TRAILS ON
00:00:00.00>FF

# Define some wayporints
00:00:00.00>DEFWPT right25 52.40798224860773, 4.853391415240031
00:00:00.00>DEFWPT right26 52.39966724826246, 4.852637328448219
00:00:00.00>DEFWPT right27 52.39135224791791, 4.85188338372578


# create aircraft
00:00:05.00>CRE AF265,A321,EEL,224,FL260,300

# Add waypoints
00:00:05.00>ORIG AF265,EKCH
00:00:05.00>DEST AF265,EHAM/RW18R
00:00:05.00>ADDWPTMODE AF265, FLYBY
00:00:05.00>ADDWPT AF265,EEL,,
00:00:05.00>ADDWPT AF265,NOVEN,,
00:00:05.00>ADDWPT AF265,ARTIP,FL100,250
00:00:05.00>ADDWPT AF265,right27,,220
00:00:05.00>ADDWPT AF265,right26,,220
00:00:05.00>ADDWPT AF265,right25,,220

00:00:05.00>LNAV AF265,ON
00:00:05.00>VNAV AF265,ON

00:00:05.00>POS AF265
00:08:25.00>HOLD
```