### PR TITLE
Fix lat lon conversion to text

### DIFF
--- a/bluesky/tools/misc.py
+++ b/bluesky/tools/misc.py
@@ -286,12 +286,12 @@ def txt2lon(lontxt):
 def lat2txt(lat):
     ''' Convert latitude into string (N/Sdegrees'minutes'seconds). '''
     d,m,s = float2degminsec(abs(lat))
-    return "NS"[lat<0] + "%02d'%02d'"%(int(d),int(m))+str(s)+'"'
+    return "NS"[bool(lat<0)] + "%02d'%02d'"%(int(d),int(m))+str(s)+'"'
 
 def lon2txt(lon):
     ''' Convert longitude into string (E/Wdegrees'minutes'seconds). '''
     d,m,s = float2degminsec(abs(lon))
-    return "EW"[lon<0] + "%03d'%02d'"%(int(d),int(m))+str(s)+'"'
+    return "EW"[bool(lon<0)] + "%03d'%02d'"%(int(d),int(m))+str(s)+'"'
 
 def latlon2txt(lat,lon):
     ''' Convert latitude and longitude in latlon string. '''


### PR DESCRIPTION
Hello, 

it seems there is an issue with lat2txt() and lon2txt() in latest numpy.

When calling an aircraft id to display the route, the following error appears

```
  File "bluesky/bluesky/tools/misc.py", line 289, in lat2txt
    return "NS"[lat<0] + "%02d'%02d'"%(int(d),int(m))+str(s)+'"'
           ~~~~^^^^^^^
TypeError: string indices must be integers, not 'numpy.bool'
```