### PR TITLE
add missing deletions to delwpt

### DIFF
--- a/bluesky/traffic/route.py
+++ b/bluesky/traffic/route.py
@@ -1378,6 +1378,13 @@ class Route(Base):
         del acrte.wpspd[wpidx]
         del acrte.wprta[wpidx]
         del acrte.wptype[wpidx]
+        del acrte.wpflyby[wpidx]
+        del acrte.wpflyturn[wpidx]
+        del acrte.wpturnbank[wpidx]
+        del acrte.wpturnrad[wpidx]
+        del acrte.wpturnspd[wpidx]
+        del acrte.wpturnhdgr[wpidx]
+        del acrte.wpstack[wpidx]
         if acrte.iactwp > wpidx:
             acrte.iactwp = max(0, acrte.iactwp - 1)
 


### PR DESCRIPTION
Hello,

The ```delwpt``` stack command was missing some deletions. This caused some weird behaviour when deleting a waypoint because the ```iactwp```was not valid for some of the waypoint lists.

-Andres