### PR TITLE
Allow for turn direction preference in 180 degree turns

### DIFF
--- a/bluesky/traffic/traffic.py
+++ b/bluesky/traffic/traffic.py
@@ -445,6 +445,13 @@ class Traffic(Entity):
                                                    self.ap.turnphi,self.ap.bankdef)) \
                                           / np.maximum(self.tas, self.eps))
         delhdg = (self.aporasas.hdg - self.hdg + 180) % 360 - 180  # [deg]
+
+        # For exactly 180-degree turns, use aircraft turn preference only apply 
+        # turn preference when turn180pref is -1 or 1, not when it's 0 (default)
+        is_180_turn = np.round(np.abs(delhdg), 5) == 180
+        use_turn_pref = np.logical_and(is_180_turn, self.ap.turn180pref)
+        turn_direction = np.sign(self.ap.turn180pref) * 180
+        delhdg = np.where(use_turn_pref, turn_direction, delhdg)
         self.swhdgsel = np.abs(delhdg) > np.abs(bs.sim.simdt * turnrate)
 
         # Update heading


### PR DESCRIPTION
Hello,

I have made some updates to `autopilot.py` and `traffic.py` to allow for choosing the turn direction when making 180 degree turns. Currently, there is no consistent way to choose which direction the aircraft takes when it has to turn 180 degrees.

## New Features

- **HDG180 Command**: `HDG180 acid,[CW/CCW]` - Turn aircraft 180 degrees with explicit direction control. Clockwise is CW and Counterclockwise is CCW.
- **TURNPREF Command**: `TURNPREF acid,[CW/CCW/DEFAULT]` - Set/get aircraft turn preferences for 180-degree turns
- Store the preference in a traffic array inside autopilot.

## Implementation

- Added `turn180pref` array to  `Autpilot` class (1=CW, -1=CCW, 0=default)
- Modified `delhdg` calculation in `traffic.py` to respect preferences for exact 180-degree turns
- Turn preference only applies when heading change is exactly 180 degrees. This had some issues in implementation, so I had to round to the nearest 5 digits due to some floating point errors when checking if the turn is equal to 180 degrees.

Let me know if this is something that would be useful, or if you would like any additional changes. For example, perhaps we don't need two stack commands or perhaps the stack command names should be different.

Best,
Andres