### PR TITLE
Stop self and cls from appearing in qt console hints

### DIFF
--- a/bluesky/stack/cmdparser.py
+++ b/bluesky/stack/cmdparser.py
@@ -115,11 +115,12 @@ class Command:
     def callback(self, function):
         self._callback = FuncObject(function)
         spec = inspect.signature(function)
+        paramspecs = list(filter(Parameter.canwrap, spec.parameters.values()))
+        paramspecnames = [p.name for p in paramspecs]
         self.brief = self.brief or (
-            self.name + ' ' + ','.join(spec.parameters))
+            self.name + ' ' + ','.join(paramspecnames))
         self.help = self.help or inspect.cleandoc(
             inspect.getdoc(function) or '')
-        paramspecs = list(filter(Parameter.canwrap, spec.parameters.values()))
         if self.annotations:
             self.params = list()
             pos = 0


### PR DESCRIPTION
Hello,

In the QT console, command hints are including `self` and `cls` arguments, like for the `WIND` and `MCRE` commands. They are correctly removed by the stack command argpaser. However, in the stack command parser, `self.brief` is generated before these arguments can be removed.  This part of the code base is a bit more unfamiliar to me, so I am not sure if this is the correct approach.

-Andres