### PR TITLE
add ability to unselect routes

### DIFF
--- a/bluesky/simulation/screenio.py
+++ b/bluesky/simulation/screenio.py
@@ -76,7 +76,21 @@ class ScreenIO(Entity):
             self.route_all = acid
             self.client_route.clear()
         else:
-            self.client_route[stack.sender()] = acid
+            # here now we need to check if sender is requesting new route or old route
+            try:
+                prev_selected_acid = self.client_route[stack.sender()]
+            except KeyError:
+                # it means there is no previously selected aircraft
+                prev_selected_acid = None
+
+            if acid != prev_selected_acid:
+                # selecting a new route
+                self.client_route[stack.sender()] = acid
+
+            elif prev_selected_acid is not None:
+                # selecting the same aircraft again so this means toggle the route
+                self.client_route.clear()
+                self.pub_route.send_delete(**{'acid' : acid})
         return True
 
     def addnavwpt(self, name, lat, lon):

--- a/bluesky/simulation/screenio.py
+++ b/bluesky/simulation/screenio.py
@@ -89,7 +89,7 @@ class ScreenIO(Entity):
 
             elif prev_selected_acid is not None:
                 # selecting the same aircraft again so this means toggle the route
-                self.client_route.clear()
+                self.client_route.pop(stack.sender())
                 self.pub_route.send_delete(**{'acid' : acid})
         return True
 

--- a/bluesky/ui/qtgl/gltraffic.py
+++ b/bluesky/ui/qtgl/gltraffic.py
@@ -272,7 +272,7 @@ class Traffic(glh.RenderObject, layer=100):
         ''' Update GPU buffers with route data from simulation. '''
         if not self.initialized:
             return
-        if ctx.action == ctx.action.Reset or ctx.action == ctx.action.ActChange:# TODO hack
+        if ctx.action in [ctx.action.Reset, ctx.action.ActChange, ctx.action.Delete]:
             # Simulation reset: Clear all entries
             self.route.set_vertex_count(0)
             self.routelbl.n_instances = 0


### PR DESCRIPTION
Hello,

Currently, it is not possible to unselect a route after asking for it. The sim nodes will keep sending the route until a reset is given.  This allows a client to deselect a route by calling `POS` again. So it effectively just toggles the route.

It should be possible to close issue #360 with this fix.

Andres