### PR TITLE
Allow zoom mistakes

### DIFF
--- a/bluesky/ui/qtgl/mainwindow.py
+++ b/bluesky/ui/qtgl/mainwindow.py
@@ -296,6 +296,8 @@ class MainWindow(QMainWindow, Base):
             - factor: IN/OUT to zoom in/out by a factor sqrt(2), or
                       'factor' to set zoom to specific value.
         '''
+        if not isinstance(factor, float):
+            return False, f'Argument error.\nUsage:\nZOOM IN/OUT/factor'
         store = ss.get(group='panzoom')
         store.zoom = factor
         self.panzoom_event.emit(store)


### PR DESCRIPTION
Currently, if you write zoom x or something unexpected in qt console, then BlueSky crashes with

```
TypeError: '>=' not supported between instances of 'str' and 'float'
``` 

I have added a small check to prevent crashes and alert the user of the correct usage

-Andres