### PR TITLE
Fix perfstats stack command

### DIFF
--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -410,10 +410,10 @@ class OpenAP(PerfBase):
         return (
             True,
             f"Flight phase: {ph.readable_phase(self.phase[acid])}\n"
-            f"Thrust: {self.thrust[acid] / 1000:d} kN\n"
-            f"Drag: {self.drag[acid] / 1000:d} kN\n"
+            f"Thrust: {self.thrust[acid] / 1000:.0f} kN\n"
+            f"Drag: {self.drag[acid] / 1000:.0f} kN\n"
             f"Fuel flow: {self.fuelflow[acid]:.2f} kg/s\n"
-            f"Speed envelope: [{self.vmin[acid] / kts:d}, {self.vmax[acid] / kts:d}] kts\n"
-            f"Vertical speed envelope: [{self.vsmin[acid] / fpm:d}, {self.vsmax[acid] / fpm:d}] fpm\n"
-            f"Ceiling: {self.hmax[acid] / ft:d} ft",
+            f"Speed envelope: [{self.vmin[acid] / kts:.0f}, {self.vmax[acid] / kts:.0f}] kts\n"
+            f"Vertical speed envelope: [{self.vsmin[acid] / fpm:.0f}, {self.vsmax[acid] / fpm:.0f}] fpm\n"
+            f"Ceiling: {self.hmax[acid] / ft:.0f} ft",
         )


### PR DESCRIPTION
Hello,

The current `PERFSTATS` stack command gives the following error

```bash
ValueError: Unknown format code 'd' for object of type 'float'
```

My suggested fix changes the format code so that it works for floats.

-Andres