### PR TITLE
fix: preserve OpenAP initial climb speed limits

### DIFF
--- a/bluesky/test/traffic/test_openap_vlimits.py
+++ b/bluesky/test/traffic/test_openap_vlimits.py
@@ -1,0 +1,29 @@
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from bluesky.traffic.performance.openap import coeff
+from bluesky.traffic.performance.openap import phase as ph
+from bluesky.traffic.performance.openap.perfoap import OpenAP
+
+
+def test_construct_v_limits_keeps_initial_climb_bounds():
+    perf = SimpleNamespace(
+        actype=np.array(["A320"]),
+        lifttype=np.array([coeff.LIFT_FIXWING]),
+        phase=np.array([ph.IC]),
+        vminic=np.array([155.0]),
+        vminer=np.array([125.0]),
+        vminap=np.array([110.0]),
+        vmaxic=np.array([210.0]),
+        vmaxer=np.array([250.0]),
+        vmaxap=np.array([160.0]),
+        vmin=np.array([0.0]),
+        vmax=np.array([0.0]),
+    )
+
+    vmin, vmax = OpenAP._construct_v_limits(perf, np.array([True], dtype=bool))
+
+    assert vmin[0] == pytest.approx(155.0)
+    assert vmax[0] == pytest.approx(210.0)

--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -358,7 +358,7 @@ class OpenAP(PerfBase):
         vminfw = np.where(self.phase[ifw] == ph.NA, 0, vminfw)
         vminfw = np.where(self.phase[ifw] == ph.IC, self.vminic[ifw], vminfw)
         vminfw = np.where(
-            (self.phase[ifw] >= ph.CL) | (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw
+            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw
         )
         vminfw = np.where(self.phase[ifw] == ph.AP, self.vminap[ifw], vminfw)
         vminfw = np.where(self.phase[ifw] == ph.GD, 0, vminfw)
@@ -367,7 +367,7 @@ class OpenAP(PerfBase):
         vmaxfw = np.where(self.phase[ifw] == ph.NA, self.vmaxer[ifw], vmaxfw)
         vmaxfw = np.where(self.phase[ifw] == ph.IC, self.vmaxic[ifw], vmaxfw)
         vmaxfw = np.where(
-            (self.phase[ifw] >= ph.CL) | (self.phase[ifw] <= ph.DE), self.vmaxer[ifw], vmaxfw
+            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vmaxer[ifw], vmaxfw
         )
         vmaxfw = np.where(self.phase[ifw] == ph.AP, self.vmaxap[ifw], vmaxfw)
         vmaxfw = np.where(self.phase[ifw] == ph.GD, self.vmaxic[ifw], vmaxfw)


### PR DESCRIPTION
## What this does
Fixes OpenAP speed envelope selection so initial-climb aircraft keep `vminic`/`vmaxic` instead of being overwritten by en-route limits. Adds a regression test for `_construct_v_limits()`.

## Why it matters
Issue #537 remains open and this bug can allow incorrect speed limits during initial climb. This patch is minimal and scoped to the faulty phase-range condition.

## How to test
1. Run `python -m py_compile bluesky/traffic/performance/openap/perfoap.py bluesky/test/traffic/test_openap_vlimits.py`.
2. Run `python -m pytest -q bluesky/test/traffic/test_openap_vlimits.py` in a Python 3.10+ env with pytest installed.

Closes #537