### PR TITLE
fix: support scalar static windfields in addpointvne

### DIFF
--- a/bluesky/test/traffic/test_windfield.py
+++ b/bluesky/test/traffic/test_windfield.py
@@ -1,0 +1,13 @@
+import pytest
+
+from bluesky.traffic.windfield import Windfield
+
+
+def test_addpointvne_static_scalar_wind_does_not_crash_getdata():
+    wind = Windfield()
+    wind.addpointvne([52.0], [4.0], 0.0, 0.0)
+
+    vnorth, veast = wind.getdata(52.1, 4.1, 1000.0)
+
+    assert vnorth == pytest.approx(0.0)
+    assert veast == pytest.approx(0.0)

--- a/bluesky/traffic/windfield.py
+++ b/bluesky/traffic/windfield.py
@@ -73,7 +73,10 @@ class Windfield():
         """ Add a vector of lat/lon positions (arrays) with a (2D vector of) 
             wind speed [m/s] in north and east component. 
             Optionally an array with altitudes can be used
-        """              
+        """
+        lat = array(lat, ndmin=1)
+        lon = array(lon, ndmin=1)
+
         if windalt is not None and len(windalt) > 1:           
             # Set altitude interpolation functions
             fnorth = interp1d(windalt, vnorth.T, bounds_error=False, 
@@ -113,8 +116,15 @@ class Windfield():
             self.iprof.append(len(self.lat) + 1)
         
         else:
-            vnaxis = vnorth
-            veaxis = veast
+            npos = len(lat)
+            vnaxis = array(vnorth, ndmin=2)
+            veaxis = array(veast, ndmin=2)
+            if vnaxis.size == 1 and npos > 1:
+                vnaxis = vnaxis * ones((1, npos))
+            if veaxis.size == 1 and npos > 1:
+                veaxis = veaxis * ones((1, npos))
+            vnaxis = vnaxis.reshape((1, npos))
+            veaxis = veaxis.reshape((1, npos))
 
         self.nvec += len(lat)
         self.lat = append(self.lat, lat)


### PR DESCRIPTION
## What this does
Fixes `Windfield.addpointvne()` so static wind inputs are normalized to a 2D shape that `getdata()` expects. This prevents crashes when scalar `vnorth`/`veast` values are used.

## Why it matters
Issue #537 reports a crash for static windfields because `getdata()` indexes `self.vnorth[0,0]` while `addpointvne()` could store a scalar/1D value.

## How to test
1. Run `python -m py_compile bluesky/traffic/windfield.py bluesky/test/traffic/test_windfield.py`.
2. Run `python -m pytest -q bluesky/test/traffic/test_windfield.py` in a Python 3.10+ environment with pytest installed.

Closes #537