### PR TITLE
Fix BADA parsing issue

### DIFF
--- a/bluesky/traffic/performance/bada/fwparser.py
+++ b/bluesky/traffic/performance/bada/fwparser.py
@@ -55,7 +55,7 @@ class FixedWidthParser:
     def parse(self, fname):
         line_re, dtypes = self.dformat[0]
         data            = []
-        with open(fname) as f:
+        with open(fname, encoding='latin-1') as f:
             for lineno, line in enumerate(f):
                 match = line_re.match(line)
                 if match:


### PR DESCRIPTION
**Description**:
Fixes parsing issue discussed in #508 

**Context:**
The BADA 3.16 dataset fails to load when parsed as UTF-8 due to the presence of special accented characters (e.g., á and è), specifically within the SYNONYM.NEW file. These characters appear to be encoded in [Latin-1](https://en.wikipedia.org/wiki/ISO/IEC_8859-1) (ISO-8859-1).

**The Fix:**
Update the parser to explicitly use Latin-1 encoding for BADA 3.x dataset files.

**Evidence:**
- Before:
<img width="745" height="65" alt="Screenshot 2026-03-16 at 2 50 48 PM" src="https://github.com/user-attachments/assets/67668ccb-70ba-4383-a37f-c864ebce5138" />

- After:
<img width="745" height="65" alt="Screenshot 2026-03-16 at 2 51 16 PM" src="https://github.com/user-attachments/assets/12c4db7e-26bb-4788-a1f5-2efafee453d7" />
