### PR TITLE
Update Aircraft Speed Logic

### DIFF
--- a/bluesky/core/trafficproxy.py
+++ b/bluesky/core/trafficproxy.py
@@ -31,10 +31,6 @@ class TrafficProxy(Base):
     # data['vmin']       = bs.traf.perf.vmin
     # data['vmax']       = bs.traf.perf.vmax
 
-
-    # # Send casmachthr for route visualization
-    # data['casmachthr']    = aero.casmach_thr
-
     # ASAS resolutions for visualization. Only send when evaluated
     # data['asastas']  = bs.traf.cr.tas
     # data['asastrk']  = bs.traf.cr.trk

--- a/bluesky/simulation/screenio.py
+++ b/bluesky/simulation/screenio.py
@@ -6,7 +6,6 @@ import numpy as np
 import bluesky as bs
 from bluesky import stack
 from bluesky.core import Entity
-from bluesky.tools import aero
 from bluesky.core.walltime import Timer
 from bluesky.network.publisher import state_publisher, StatePublisher
 
@@ -169,9 +168,6 @@ class ScreenIO(Entity):
 
         # Transition level as defined in traf
         data['translvl']   = bs.traf.translvl
-
-        # Send casmachthr for route visualization
-        data['casmachthr']    = aero.casmach_thr
 
         # ASAS resolutions for visualization. Only send when evaluated
         data['asastas']  = bs.traf.cr.tas

--- a/bluesky/stack/basecmds.py
+++ b/bluesky/stack/basecmds.py
@@ -113,14 +113,6 @@ def initbasecmds():
             calculator,
             "Simple in-line math calculator, evaluates expression",
         ],
-        "CASMACHTHR": [
-            "CASMACHTHR threshold",
-            "float",
-            aero.casmachthr,
-            """Set a threshold below which speeds should be considered as Mach numbers
-               in CRE(ATE), ADDWPT, and SPD commands. Set to zero if speeds should
-               never be considered as Mach number(e.g., when simulating drones)."""
-        ],
         "CD": [
             "CD [path]",
             "[word]",

--- a/bluesky/tools/aero.py
+++ b/bluesky/tools/aero.py
@@ -3,10 +3,6 @@
 from math import *
 import numpy as np
 
-from bluesky import settings
-
-
-settings.set_variable_defaults(casmach_threshold=2.0)
 # International standard atmpshere only up to 72000 ft / 22 km
 
 #
@@ -31,25 +27,6 @@ gamma2 = 3.5                # gamma/(gamma-1) for air
 beta = -0.0065              # [K/m] ISA temp gradient below tropopause
 Rearth = 6371000.           # m  Average earth radius
 a0  = np.sqrt(gamma*R*T0)   # sea level speed of sound ISA
-casmach_thr = settings.casmach_threshold # Threshold below which speeds should
-                            # be considered as Mach numbers in casormach* functions
-
-
-def casmachthr(threshold:float=None):
-    """ CASMACHTHR threshold
-
-        Set a threshold below which speeds should be considered as Mach numbers
-        in CRE(ATE), ADDWPT, and SPD commands. Set to zero if speeds should
-        never be considered as Mach number (e.g., when simulating drones).
-
-        Argument:
-        - threshold: CAS speed threshold [m/s]
-    """
-    if threshold is None:
-        return True, f'CASMACHTHR: The current CAS/Mach threshold is {casmach_thr} m/s ({casmach_thr / kts} kts'
-
-    globals()['casmach_thr'] = threshold
-    return True, f'CASMACHTHR: Set CAS/Mach threshold to {threshold}'
 
 
 #
@@ -302,10 +279,12 @@ def vcasormach(spd, h):
         - cas: Calibrated airspeed [m/s]
         - mach: Mach number [-]
     """
-    ismach = np.logical_and(spd > 0.1, spd < casmach_thr)
-    tas = np.where(ismach, vmach2tas(spd, h), vcas2tas(spd, h))
+    # Negative spd encodes Mach (magnitude = Mach number); positive encodes CAS [m/s]
+    ismach = spd < 0
+    mach_magnitude = np.abs(spd)
+    tas = np.where(ismach, vmach2tas(mach_magnitude, h), vcas2tas(spd, h))
     cas = np.where(ismach, vtas2cas(tas, h), spd)
-    mach   = np.where(ismach, spd, vtas2mach(tas, h))
+    mach = np.where(ismach, mach_magnitude, vtas2mach(tas, h))
     return tas, cas, mach
 
 
@@ -313,15 +292,15 @@ def vcasormach2tas(spd, h):
     """ Interpret input speed as either CAS or a Mach number, and return TAS.
 
         Arguments:
-        - spd: Airspeed. Interpreted as Mach number [-] when its value is below the
-               CAS/Mach threshold. Otherwise interpreted as CAS [m/s].
+         - spd: Airspeed. Negative = Mach number [-] (e.g. -0.82 = Mach 0.82).
+             Positive = CAS [m/s].
         - h: Altitude [m]
 
         Returns:
         - tas: True airspeed [m/s]
     """
-    ismach = np.logical_and(spd > 0.1, spd < casmach_thr)
-    return np.where(ismach, vmach2tas(spd, h), vcas2tas(spd, h))
+    ismach = spd < 0
+    return np.where(ismach, vmach2tas(np.abs(spd), h), vcas2tas(spd, h))
 
 
 def crossoveralt(cas, mach):
@@ -544,25 +523,27 @@ def cas2mach(cas, h):
     return M
 
 def casormach(spd,h):
-    if 0.1 < spd < casmach_thr:
-        # Interpret spd as Mach number
-        tas = mach2tas(spd, h)
-        cas = mach2cas(spd, h)
-        m   = spd
+    """ Scalar version of vcasormach. Negative spd = Mach, positive spd = CAS [m/s]. """
+    if spd < 0:
+        # Negative encodes Mach number (magnitude = Mach)
+        m   = -spd
+        tas = mach2tas(m, h)
+        cas = mach2cas(m, h)
     else:
-        # Interpret spd as CAS
-        tas = cas2tas(spd,h)
+        # Positive = CAS in m/s
+        tas = cas2tas(spd, h)
         cas = spd
         m   = cas2mach(spd, h)
     return tas, cas, m
 
 def casormach2tas(spd,h):
-    if 0.1 < spd < casmach_thr:
-        # Interpret spd as Mach number
-        tas = mach2tas(spd, h)
+    """ Scalar version of vcasormach2tas. Negative spd = Mach, positive spd = CAS [m/s]. """
+    if spd < 0:
+        # Negative encodes Mach number (magnitude = Mach)
+        tas = mach2tas(-spd, h)
     else:
-        # Interpret spd as CAS
-        tas = cas2tas(spd,h)
+        # Positive = CAS in m/s
+        tas = cas2tas(spd, h)
     return tas
 
 

--- a/bluesky/tools/misc.py
+++ b/bluesky/tools/misc.py
@@ -155,7 +155,6 @@ def txt2spd(txt):
     try:
         txt = txt.upper().strip()
         if txt.startswith('M'):
-            # Mach number
             mach_txt = txt[1:]
             if '.' in mach_txt:
                 # Explicit decimal notation: M0.82, M2.0

--- a/bluesky/traffic/performance/bada/perfbada.py
+++ b/bluesky/traffic/performance/bada/perfbada.py
@@ -374,7 +374,7 @@ class BADA(PerfBase):
 
         # energy share factor
         delspd = bs.traf.aporasas.tas - bs.traf.tas
-        selmach = bs.traf.selspd < 2.0
+        selmach = bs.traf.selspd < 0  # Negative selspd encodes Mach; positive = CAS in m/s
         self.ESF = esf(bs.traf.alt, bs.traf.M, climb, descent, delspd, selmach)
 
         # THRUST

--- a/bluesky/traffic/performance/legacy/perfbs.py
+++ b/bluesky/traffic/performance/legacy/perfbs.py
@@ -250,7 +250,7 @@ class Legacy(PerfBase):
 
         # energy share factor
         delspd = bs.traf.aporasas.tas - bs.traf.tas
-        selmach = bs.traf.selspd < 2.0
+        selmach = bs.traf.selspd < 0  # Negative selspd encodes Mach; positive = CAS in m/s
         self.ESF = esf(bs.traf.alt, bs.traf.M, climb, descent, delspd, selmach)
 
         # determine thrust

--- a/bluesky/traffic/route.py
+++ b/bluesky/traffic/route.py
@@ -51,7 +51,7 @@ class Route(Base):
         self.wplat  = []    # List of waypoint latitudes
         self.wplon  = []    # List of waypoint longitudes
         self.wpalt  = []    # [m] negative value means not specified
-        self.wpspd  = []    # [m/s] negative value means not specified
+        self.wpspd  = []    # Negative = Mach (e.g. -0.82 = Mach 0.82), positive = CAS [m/s], -999 = not specified
         self.wprta  = []    # [m/s] negative value means not specified
         self.wpflyby = []   # Flyby (True)/flyover(False) switch
         self.wpstack = []   # Stack with command execured when passing this waypoint
@@ -683,9 +683,11 @@ class Route(Base):
 
                 # Show speed
                 if swspd:
-                    if acrte.wpspd[wpidx] < 0:
+                    if acrte.wpspd[wpidx] <= -999:   # not specified
                         txt += "---"
-                    else:
+                    elif acrte.wpspd[wpidx] < 0:     # Mach (stored negative)
+                        txt += f"M{-acrte.wpspd[wpidx]:.2f}"
+                    else:                             # CAS in m/s
                         txt += str(int(round(acrte.wpspd[wpidx] / kts)))
 
                 # Type
@@ -1065,7 +1067,7 @@ class Route(Base):
                                     acrte.wptorta[wpidx],acrte.wpxtorta[wpidx])
 
         # If there is a speed specified, process it
-        if acrte.wpspd[wpidx]>0.:
+        if acrte.wpspd[wpidx] > -999.:  # speed is specified (CAS>0 or Mach<0)
             # Set target speed for autopilot
 
             if acrte.wpalt[wpidx] < 0.0:
@@ -1074,8 +1076,8 @@ class Route(Base):
                 alt = acrte.wpalt[wpidx]
 
             # Check for valid Mach or CAS
-            if acrte.wpspd[wpidx] <2.0:
-                cas = mach2cas(acrte.wpspd[wpidx], alt)
+            if acrte.wpspd[wpidx] < 0:
+                cas = mach2cas(-acrte.wpspd[wpidx], alt)
             else:
                 cas = acrte.wpspd[wpidx]
 
@@ -1172,12 +1174,12 @@ class Route(Base):
                     txt += str(int(round(acrte.wpalt[i] / ft))) + "/"
 
                 # Speed
-                if acrte.wpspd[i] < 0.:
+                if acrte.wpspd[i] <= -999.:           # not specified
                     txt += "---"
-                elif acrte.wpspd[i] > 2.0:
+                elif acrte.wpspd[i] < 0.:             # Mach (stored negative)
+                    txt += f"M{-acrte.wpspd[i]:.2f}"
+                else:                                  # CAS in m/s
                     txt += str(int(round(acrte.wpspd[i] / kts)))
-                else:
-                    txt += "M" + str(acrte.wpspd[i])
 
                 # Type: orig, dest, C = flyby, | = flyover, U = flyturn
                 if acrte.wptype[i] == Route.orig:
@@ -1506,7 +1508,7 @@ class Route(Base):
                 else:
                     if i != self.nwp - 1:
                         # No speed or rta constraint: add to xtorta
-                        if self.wpspd[i] <= 0.0:
+                        if self.wpspd[i] <= -999.:  # no speed constraint
                             xtorta = xtorta + self.wpdistto[i + 1] * nm  # [m] xtoalt is in meters!
                         else:
                             # speed constraint on this leg: shift torta to account for this

--- a/bluesky/ui/qtgl/gltraffic.py
+++ b/bluesky/ui/qtgl/gltraffic.py
@@ -310,13 +310,12 @@ class Traffic(glh.RenderObject, layer=100):
                         txt += "%05d/" % int(round(alt / ft))
 
                     # Speed
-                    if spd < 0:
+                    if spd <= -999:                   # not specified
                         txt += "--- "
-                    # TODO: get from sim
-                    elif spd > settings.casmach_threshold:
+                    elif spd < 0:                     # Mach (stored negative)
+                        txt += f"M{-spd:.2f}"
+                    else:                             # CAS in m/s
                         txt += "%03d" % int(round(spd / kts))
-                    else:
-                        txt += f"M{spd:.2f}" # Mach number
 
                 wpname += txt.ljust(24)  # Fill out with spaces
             self.routelbl.update(texdepth=np.array(wpname.encode('ascii', 'ignore')),


### PR DESCRIPTION
**Description**
This pull-request reworks how speeds are represented and parsed throughout BlueSky, specifically focusing on distinguishing between Mach numbers and CAS. The changes correct speed handling and update parsing to support [ICAO Doc 4444](https://recursosdeaviacion.com/wp-content/uploads/2021/01/icao-doc-4444-air-traffic-management.pdf) notation.

**Context**
Previously, BlueSky exhibited incorrect speed behavior due to the positive threshold logic used for Mach values. For instance, setting an aircraft's speed to 3 caused it to accelerate to its maximum speed (interpreted as Mach 1.543), whereas setting it to 5 resulted in a speed of 5 knots:

> `CRE A B733 52.194384,3.44831 360 0 200`
> `SPD A 5` (Interpreted as 5 knots) 👍
> `SPD A 3` (Interpreted as Mach 1.543) 👎

Additionally, parsing for the M prefix was inconsistent. While M65 correctly set the speed to Mach 0.65, attempting to use `M200` incorrectly set the aircraft to Mach 0.2 instead of the (arguably deadly) selected speed of Mach 2.0:

> `CRE A B733 52.194384,3.44831 360 FL150 200`
> `SPD A M65` (Correctly sets to Mach 0.65) 👍
> `SPD A M200` (Incorrectly sets to Mach 0.2) 👎

The proposed update fixes these issues

**Fix**
1. Speed Representation Update
- All code now uses negative values to represent Mach speeds (e.g., -0.82 for Mach 0.82) and positive values for CAS (in m/s). This completely eliminates the previous `casmach_thr` threshold logic
- The `casmach_thr` global variable, related settings, and the `CASMACHTHR` command are removed entirely, as the new encoding makes them unnecessary.

2. Speed Parsing Improvements:
- The `txt2spd` and `txt2tas` functions now support ICAO Doc 4444 speed notation (e.g., `N0485` for knots, `M082` for Mach 0.82), as well as explicit decimal Mach and plain knot values for backward compatibility. The parsing functions return negative floats for Mach and positive for CAS, matching the new convention.

3. Route and UI Handling:
- Route waypoint speed fields and all related display, logic, and UI code are updated to use the new encoding, including handling of "not specified" speeds with a sentinel value (-999).