### PR TITLE
Fix clipboard paste handling in the Qt UI- tested on Mac OS

### DIFF
--- a/bluesky/ui/qtgl/console.py
+++ b/bluesky/ui/qtgl/console.py
@@ -161,6 +161,16 @@ class Console(QWidget):
                 # self.radarwidget.previewpoly(None)
                 return
 
+        if event.key() == Qt.Key.Key_V and event.modifiers() & (Qt.KeyboardModifier.MetaModifier | Qt.KeyboardModifier.ControlModifier):
+            clipboard = QApplication.clipboard()
+            text = clipboard.text()
+            if text:
+                text = text.replace('\x00', '').strip('\r\n')
+                pos = self.lineEdit.cursor_pos()
+                newcmd = self.command_line[:pos] + text + self.command_line[pos:]
+                self.set_cmdline(newcmd, pos + len(text))
+            return
+
         newcmd = self.command_line
         cursorpos = None
         if event.key() >= Qt.Key.Key_Space and event.key() <= Qt.Key.Key_AsciiTilde \


### PR DESCRIPTION
This pull request fixes the handling of the paste (Ctrl+V / Cmd+V) into the command line of the Qt UI. This partially addresses #534 
The clipboard content is checked for \r \n, which are removed. In addition, the cursor position is moved with the text.

Tested on Mac only.