### PR TITLE
Fix C Implementation of Geo Module

### DIFF
--- a/bluesky/tools/geo/src_cpp/_cgeo.cpp
+++ b/bluesky/tools/geo/src_cpp/_cgeo.cpp
@@ -562,7 +562,7 @@ static PyObject* cgeo_kwikqdrdist(PyObject* self, PyObject* args)
         }
         Py_DECREF(arr1);
         Py_DECREF(arr2);
-        return dst;
+        return Py_BuildValue("NN", qdr, dst);
     }
     // Arguments should be all scalars
     kwik_in in(DEG2RAD * PyFloat_AsDouble(arg1),

--- a/bluesky/tools/geo/src_cpp/geo.hpp
+++ b/bluesky/tools/geo/src_cpp/geo.hpp
@@ -124,8 +124,10 @@ inline pos kwikpos(const double& lat1, const double& lon1, const double& qdr, co
 }
 
 struct kwik_in {double dlat, dlon, cavelat;
+    // remainder() wraps the longitude difference to [-pi, pi] so the shortest
+    // way around is taken (e.g. across the antimeridian).
     kwik_in(const double& lat1, const double& lon1, const double& lat2, const double& lon2) :
-        dlat(lat2 - lat1), dlon(lon2 - lon1), cavelat(cos(0.5 * (lat1 + lat2))) {};
+        dlat(lat2 - lat1), dlon(remainder(lon2 - lon1, 2.0 * M_PI)), cavelat(cos(0.5 * (lat1 + lat2))) {};
 };
 
 // quick distance calculation (using equirectangular distance approximation)

--- a/bluesky/tools/geo/src_cpp/geo.hpp
+++ b/bluesky/tools/geo/src_cpp/geo.hpp
@@ -146,5 +146,8 @@ inline double kwikdist(const kwik_in& in)
 
 inline double kwikqdr(const kwik_in &in)
 {
-    return fmod(atan2(in.dlon * in.cavelat, in.dlat), 360.0);
+    // atan2() returns an angle in the range [-π, π]. Normalize negative
+    // values to [0, 2π) so the bearing is always expressed as a positive angle.
+    double qdr = atan2(in.dlon * in.cavelat, in.dlat);
+    return qdr < 0.0 ? qdr + 2.0 * M_PI : qdr;
 }


### PR DESCRIPTION
### Description
Fixes the C implementations of [kwikqdr](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/src_cpp/geo.hpp#L147) and [kwikqdrdist](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/src_cpp/_cgeo.cpp#L518).
The output issue affecting kwikqdrdist was reported in #649.

**Update:** Also updates [kwik_in](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/src_cpp/geo.hpp#L126) for consistency with python implementation (i.e. compute shortest way around the globe in longitude). Refer to dlat and dlon computation in python Geo module [[1]](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/_geo.py#L309) [[2]](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/_geo.py#L346) [[3]](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/_geo.py#L329) [[4]](https://github.com/TUDelft-CNS-ATM/bluesky/blob/7cd5dd430a2e89f6b993cc1e52e3d70674b91219/bluesky/tools/geo/_geo.py#L358).
For example, if
* lon1 = 179°
* lon2 = -179°
the shortest longitudinal difference is dlon = 2°, whereas a direct subtraction yields dlon = -358°.

### Context
Two issues were identified in the C implementation of the geo module:
1. kwikqdr was not consistent with the Python implementation. The discrepancy was caused by [fmod](https://cplusplus.com/reference/cmath/fmod), which preserves the sign of negative values, whereas Python’s modulo operator always returns a non-negative remainder for a positive divisor.
2. kwikqdrdist computed the qdr value but silently omitted it from the returned result.

### Evidence

1.  Modulo definition discrepancy
- Python modulo
> <img width="306" height="104" alt="Screenshot 2026-07-10 at 10 33 19 PM" src="https://github.com/user-attachments/assets/9c8469eb-81b2-48f2-b2df-0f6df6cc1aa7" />

- C fmod
> <img width="856" height="226" alt="Screenshot 2026-07-10 at 10 32 34 PM" src="https://github.com/user-attachments/assets/6dcb6377-1a54-4a52-896a-96f2699837f5" />

2. Notice that c-kwikqdrdist does not output qdr
> <img width="734" height="268" alt="Screenshot 2026-07-10 at 10 23 58 PM" src="https://github.com/user-attachments/assets/d7c73627-ac06-4104-8fdf-ee7de816d279" />

### Fix
1. Normalize the result of fmod to match the behavior of Python’s modulo operator.
2. Include the computed qdr value when constructing the return value with Py_BuildValue, so kwikqdrdist returns both the bearing and distance as intended.
> <img width="734" height="268" alt="Screenshot 2026-07-10 at 10 24 16 PM" src="https://github.com/user-attachments/assets/d63c27ef-072f-4cd0-9c8c-794a16dc171a" />

### Comments
While I have confirmed that these functions are now fixed and performed the above check, I recommend verifying that they do not affect any downstream functions.