### PR TITLE
Fix OpenAP Performance Model

### DIFF
--- a/bluesky/traffic/performance/openap/coeff.py
+++ b/bluesky/traffic/performance/openap/coeff.py
@@ -109,10 +109,9 @@ class Coefficient:
             )
 
             limits_fixwing[mdl]["vsmin"] = min(
-                wrap.initclimb_vs()[_MIN],
-                wrap.climb_vs_pre_concas()[_MIN],
-                wrap.climb_vs_concas()[_MIN],
-                wrap.climb_vs_conmach()[_MIN],
+                wrap.descent_vs_conmach()[_MIN],
+                wrap.descent_vs_concas()[_MIN],
+                wrap.descent_vs_post_concas()[_MIN],
             )
 
         return limits_fixwing


### PR DESCRIPTION
# Description

In the OpenAP performance model, vsmin is meant to be the maximum descent rate (a negative vertical speed). Instead it is computed from the minimum climb rate (which is a positive value).

See #651 

# Reproduction
```python
import bluesky as bs, numpy as np
from bluesky.tools import aero          # ft, fpm, kts, nm ...

bs.init(mode="sim", detached=True)
bs.traf.cre(acid="KL1", actype="A320", aclat=52.0, aclon=4.0, achdg=90.0,
            acalt=35000*aero.ft, acspd=250.0)
perf = bs.traf.perf
print("vsmax", perf.vsmax[0], "m/s")   # +16.04
print("vsmin", perf.vsmin[0], "m/s")   # +3.60  <-- positive, should be negative

n = bs.traf.ntraf
for cmd in (2000, 0, -1000, -2000, -3000):   # ft/min
    intent = np.full(n, cmd*aero.fpm)                       # ft/min -> m/s
    _, allow, _ = perf.limits(bs.traf.tas.copy(), intent, bs.traf.alt.copy(), np.zeros(n))
    print(f"commanded {cmd:+6d} -> allowed {allow[0]/aero.fpm:+7.0f} ft/min")
```

# Before fix
```python
vsmax 16.04 m/s
vsmin 3.6 m/s
commanded  +2000 -> allowed   +2000 ft/min
commanded     +0 -> allowed      +0 ft/min
commanded  -1000 -> allowed    +709 ft/min
commanded  -2000 -> allowed    +709 ft/min
commanded  -3000 -> allowed    +709 ft/min
```

# After fix
```python
vsmax 16.04 m/s
vsmin -14.68 m/s
commanded  +2000 -> allowed   +2000 ft/min
commanded     +0 -> allowed      +0 ft/min
commanded  -1000 -> allowed   -1000 ft/min
commanded  -2000 -> allowed   -2000 ft/min
commanded  -3000 -> allowed   -2890 ft/min
```