### PR TITLE
Fix Phase Condition in Speed Envelope

### DIFF
--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -358,7 +358,7 @@ class OpenAP(PerfBase):
         vminfw = np.where(self.phase[ifw] == ph.NA, 0, vminfw)
         vminfw = np.where(self.phase[ifw] == ph.IC, self.vminic[ifw], vminfw)
         vminfw = np.where(
-            (self.phase[ifw] >= ph.CL) | (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw
+            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw
         )
         vminfw = np.where(self.phase[ifw] == ph.AP, self.vminap[ifw], vminfw)
         vminfw = np.where(self.phase[ifw] == ph.GD, 0, vminfw)
@@ -367,7 +367,7 @@ class OpenAP(PerfBase):
         vmaxfw = np.where(self.phase[ifw] == ph.NA, self.vmaxer[ifw], vmaxfw)
         vmaxfw = np.where(self.phase[ifw] == ph.IC, self.vmaxic[ifw], vmaxfw)
         vmaxfw = np.where(
-            (self.phase[ifw] >= ph.CL) | (self.phase[ifw] <= ph.DE), self.vmaxer[ifw], vmaxfw
+            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vmaxer[ifw], vmaxfw
         )
         vmaxfw = np.where(self.phase[ifw] == ph.AP, self.vmaxap[ifw], vmaxfw)
         vmaxfw = np.where(self.phase[ifw] == ph.GD, self.vmaxic[ifw], vmaxfw)

--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -348,29 +348,21 @@ class OpenAP(PerfBase):
         vmax = np.zeros(n)
 
         ifw = np.where(np.logical_and(self.lifttype == coeff.LIFT_FIXWING, mask))[0]
-        vminfw = np.zeros(len(ifw))
-        vmaxfw = np.zeros(len(ifw))
+        phase_ifw = self.phase[ifw]
 
         # fixwing
         # obtain flight envelope for speed, roc, and alt, based on flight phase
+        enroute = (phase_ifw == ph.CL) | (phase_ifw == ph.CR) | (phase_ifw == ph.DE)
+        conditions = [phase_ifw == ph.GD, phase_ifw == ph.IC, enroute, phase_ifw == ph.AP]
 
-        # --- minimum speed ---
-        vminfw = np.where(self.phase[ifw] == ph.NA, self.vminer[ifw], vminfw)
-        vminfw = np.where(self.phase[ifw] == ph.IC, self.vminic[ifw], vminfw)
-        vminfw = np.where(
-            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw
+        vminfw = np.select(
+            conditions, [0, self.vminic[ifw], self.vminer[ifw], self.vminap[ifw]],
+            default=self.vminer[ifw],
         )
-        vminfw = np.where(self.phase[ifw] == ph.AP, self.vminap[ifw], vminfw)
-        vminfw = np.where(self.phase[ifw] == ph.GD, 0, vminfw)
-
-        # --- maximum speed ---
-        vmaxfw = np.where(self.phase[ifw] == ph.NA, self.vmaxer[ifw], vmaxfw)
-        vmaxfw = np.where(self.phase[ifw] == ph.IC, self.vmaxic[ifw], vmaxfw)
-        vmaxfw = np.where(
-            (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vmaxer[ifw], vmaxfw
+        vmaxfw = np.select(
+            conditions, [self.vmaxic[ifw], self.vmaxic[ifw], self.vmaxer[ifw], self.vmaxap[ifw]],
+            default=self.vmaxer[ifw],
         )
-        vmaxfw = np.where(self.phase[ifw] == ph.AP, self.vmaxap[ifw], vmaxfw)
-        vmaxfw = np.where(self.phase[ifw] == ph.GD, self.vmaxic[ifw], vmaxfw)
 
         # rotor
         ir = np.where(np.logical_and(self.lifttype == coeff.LIFT_ROTOR, mask))[0]

--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -355,7 +355,7 @@ class OpenAP(PerfBase):
         # obtain flight envelope for speed, roc, and alt, based on flight phase
 
         # --- minimum speed ---
-        vminfw = np.where(self.phase[ifw] == ph.NA, 0, vminfw)
+        vminfw = np.where(self.phase[ifw] == ph.NA, self.vminer[ifw], vminfw)
         vminfw = np.where(self.phase[ifw] == ph.IC, self.vminic[ifw], vminfw)
         vminfw = np.where(
             (self.phase[ifw] >= ph.CL) & (self.phase[ifw] <= ph.DE), self.vminer[ifw], vminfw


### PR DESCRIPTION
# Summary

The fixed-wing speed envelope contained a boolean operator bug that caused an enroute phase check to match every flight phase. This masked a second bug where unclassified (`NA`) aircraft were assigned `vmin=0` instead of a safe minimum speed. This change fixes both issues and replaces the fragile range-based phase check with explicit phase matching.

# Problem

### 1. The range check always evaluated to `True`

The code intended to identify enroute phases (`CL`, `CR`, and `DE`) using:

```python
(self.phase[ifw] >= ph.CL) | (self.phase[ifw] <= ph.DE)
```

Given the phase encoding:

```text
NA=0, GD=1, IC=2, CL=3, CR=4, DE=5, AP=6
```

every phase satisfies either `phase >= CL` or `phase <= DE`. As a result, the condition always evaluated to `True`, overwriting the intended per-phase limits. The most visible consequence was that `IC` (initial climb) aircraft received the enroute minimum speed (`vminer`) instead of the intended `vminic`.

### 2. Correcting the operator exposed a second bug

Changing the condition from `|` to `&` limited the match to only `CL`, `CR`, and `DE`, revealing a previously hidden issue.

Under the buggy OR condition, `phase == NA` was also matched and therefore overwritten from the earlier hardcoded `0` to `vminer`, masking the following line:

```python
vminfw = np.where(self.phase[ifw] == ph.NA, 0, vminfw)
```

This matters in practice because `phase.py` does not classify aircraft flying level (`|roc| < 150 fpm`) below `FL100`. Such aircraft fall through to `NA`, causing them to lose stall protection by receiving `vmin=0`.

### 3. A range comparison was the wrong abstraction

Commit 34e7668a shows that the original implementation explicitly matched each enroute phase:

```python
(phase == CL) | (phase == CR) | (phase == DE)
```

# Fix

Replace the range comparison with explicit phase matching and make the fallback for `NA` an explicit default rather than relying on assignments performed earlier in the function.

```python
enroute = (phase_ifw == ph.CL) | (phase_ifw == ph.CR) | (phase_ifw == ph.DE)
conditions = [phase_ifw == ph.GD, phase_ifw == ph.IC, enroute, phase_ifw == ph.AP]

vminfw = np.select(
    conditions,
    [0, self.vminic[ifw], self.vminer[ifw], self.vminap[ifw]],
    default=self.vminer[ifw],
)

vmaxfw = np.select(
    conditions,
    [self.vmaxic[ifw], self.vmaxic[ifw], self.vmaxer[ifw], self.vmaxap[ifw]],
    default=self.vmaxer[ifw],
)
```

# Reproduction

```python
bs.init(mode='sim', detached=True)

def dump_openap(acid, idx):
    """Print the raw OpenAP performance values for one aircraft."""
    perf = bs.traf.perf
    print(f'    {acid}:')
    print(f'    phase   : {names[int(perf.phase[idx])]}')
    print(f'    alt (ft): {bs.traf.alt[idx] / ft:.0f}')
    print(f'    vs (fpm): {bs.traf.vs[idx] / fpm:.0f}')
    print(f'    vmin/vmax (kt)  : {perf.vmin[idx] / kts:.1f} / {perf.vmax[idx] / kts:.1f}')
    print(f'    vminic/vmaxic   : {perf.vminic[idx] / kts:.1f} / {perf.vmaxic[idx] / kts:.1f}')
    print(f'    vminer/vmaxer   : {perf.vminer[idx] / kts:.1f} / {perf.vmaxer[idx] / kts:.1f}')
    print(f'    vminap/vmaxap   : {perf.vminap[idx] / kts:.1f} / {perf.vmaxap[idx] / kts:.1f}')


import bluesky.stack.simstack as simstack

names = {0: 'NA', 1: 'GD', 2: 'IC', 3: 'CL', 4: 'CR', 5: 'DE', 6: 'AP'}

# (acid, start_alt_ft, target_alt_ft_or_None, expected_phase_code, label)
cases = [
    ('AC_GD', 0,     None,  1, 'GD  on ground'),
    ('AC_IC', 200,   5000,  2, 'IC  initial climb (75-1000ft, climbing)'),
    ('AC_CL', 3000,  15000, 3, 'CL  climb (>1000ft, climbing)'),
    ('AC_CR', 35000, None,  4, 'CR  cruise (>=10000ft, level)'),
    ('AC_DE', 15000, 3000,  5, 'DE  descent (>1000ft, descending)'),
    ('AC_AP', 800,   0,     6, 'AP  approach (75-1000ft, descending)'),
    ('AC_NA', 9800,  None,  0, 'NA  level flight below FL100 (the classification gap)'),
]

for acid, alt0, alt_target, target_phase, label in cases:
    bs.stack.stack(f'CRE {acid},A320,52.0,4.0,90,{alt0},250')
    bs.sim.step()
    if alt_target is not None:
        bs.stack.stack(f'ALT {acid},{alt_target}')

    idx = bs.traf.id2idx(acid)
    reached = False
    for i in range(600):
        bs.sim.step()
        if int(bs.traf.perf.phase[idx]) == target_phase:
            reached = True
            break

    captured.clear()
    bs.stack.stack(f'PERFSTATS {acid}')
    bs.stack.process()  

    if not reached:
        got = names[int(bs.traf.perf.phase[idx])]
        print(f'{label:<45} NEVER REACHED target phase in 600 steps (currently {got})')
        dump_openap(acid, idx)
        continue

    speed_line = next(
        (line for line in captured[-1].splitlines() if line.startswith('Speed envelope')),
        '(no Speed envelope line found)',
    )
    print(f'{label:<45} {speed_line}')
    dump_openap(acid, idx)


```

# Evidence
**Before:**
```python
GD  on ground                                 Speed envelope: [0, 173] kts
    AC_GD:
    phase   : GD
    alt (ft): 0
    vs (fpm): 0
    vmin/vmax (kt)  : 0.0 / 173.0
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
IC  initial climb (75-1000ft, climbing)       Speed envelope: [130, 317] kts
    AC_IC:
    phase   : IC
    alt (ft): 326
    vs (fpm): 1500
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
CL  climb (>1000ft, climbing)                 Speed envelope: [130, 317] kts
    AC_CL:
    phase   : CL
    alt (ft): 3103
    vs (fpm): 1500
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
CR  cruise (>=10000ft, level)                 Speed envelope: [130, 317] kts
    AC_CR:
    phase   : CR
    alt (ft): 35000
    vs (fpm): 0
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
DE  descent (>1000ft, descending)             Speed envelope: [130, 317] kts
    AC_DE:
    phase   : DE
    alt (ft): 14942
    vs (fpm): -1500
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
AP  approach (75-1000ft, descending)          Speed envelope: [130, 150] kts
    AC_AP:
    phase   : AP
    alt (ft): 763
    vs (fpm): -1140
    vmin/vmax (kt)  : 130.2 / 149.7
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
NA  level flight below FL100 (the classification gap) Speed envelope: [130, 317] kts
    AC_NA:
    phase   : NA
    alt (ft): 9800
    vs (fpm): 0
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
```

**After:**
```python
GD  on ground                                 Speed envelope: [0, 173] kts
    AC_GD:
    phase   : GD
    alt (ft): 0
    vs (fpm): 0
    vmin/vmax (kt)  : 0.0 / 173.0
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
IC  initial climb (75-1000ft, climbing)       Speed envelope: [148, 173] kts
    AC_IC:
    phase   : IC
    alt (ft): 422
    vs (fpm): 1500
    vmin/vmax (kt)  : 147.7 / 173.0
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
CL  climb (>1000ft, climbing)                 Speed envelope: [130, 317] kts
    AC_CL:
    phase   : CL
    alt (ft): 3199
    vs (fpm): 1500
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
CR  cruise (>=10000ft, level)                 Speed envelope: [130, 317] kts
    AC_CR:
    phase   : CR
    alt (ft): 35000
    vs (fpm): 0
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
DE  descent (>1000ft, descending)             Speed envelope: [130, 317] kts
    AC_DE:
    phase   : DE
    alt (ft): 14846
    vs (fpm): -1500
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
AP  approach (75-1000ft, descending)          Speed envelope: [130, 150] kts
    AC_AP:
    phase   : AP
    alt (ft): 668
    vs (fpm): -1500
    vmin/vmax (kt)  : 130.2 / 149.7
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
NA  level flight below FL100 (the classification gap) Speed envelope: [130, 317] kts
    AC_NA:
    phase   : NA
    alt (ft): 9800
    vs (fpm): 0
    vmin/vmax (kt)  : 130.2 / 316.8
    vminic/vmaxic   : 147.7 / 173.0
    vminer/vmaxer   : 130.2 / 316.8
    vminap/vmaxap   : 130.2 / 149.7
```