### PR TITLE
Extract traffic kinematics into a replaceable Kinematics class

### DIFF
--- a/bluesky/traffic/kinematics.py
+++ b/bluesky/traffic/kinematics.py
@@ -1,0 +1,131 @@
+""" BlueSky kinematics implementation.
+
+This module contains the point-mass kinematics that integrate the aircraft
+state (airspeed, heading, vertical speed, ground speed, track and position)
+each simulation step. It is factored out of Traffic into a separate,
+replaceable Entity so that the kinematics model can be swapped for an
+alternative implementation (e.g. from a plugin) with Kinematics.select().
+
+The fundamental aircraft state (lat, lon, alt, tas, hdg, vs, ...) lives on
+Traffic and is shared with the rest of BlueSky; the kinematics model reads and
+writes it through the global bs.traf reference, exactly like the other flight
+models (autopilot, ASAS, ...). The state produced by the integration itself
+(the longitudinal/vertical accelerations and the turn/altitude-capture
+switches) is owned here as traffic arrays.
+"""
+import numpy as np
+
+import bluesky as bs
+from bluesky.core import Entity
+from bluesky.tools.aero import fpm, ft, g0, Rearth, vtas2cas, vtas2mach
+
+
+class Kinematics(Entity, replaceable=True):
+    """ Default BlueSky point-mass kinematics.
+
+    Integrates airspeed/heading/vertical speed, derives ground speed and
+    track (including wind), and updates the aircraft position each step.
+    """
+
+    def __init__(self):
+        super().__init__()
+
+        with self.settrafarrays():
+            # Accelerations produced by the integration
+            self.ax       = np.array([])              # [m/s2] current longitudinal acceleration
+            self.az       = np.array([])              # [m/s2] current vertical acceleration
+
+            # Guidance-mode switches produced by the integration
+            self.swhdgsel = np.array([], dtype=bool)  # whether aircraft is turning
+            self.swaltsel = np.array([], dtype=bool)  # whether altitude capture/hold is engaged
+
+    def create(self, n=1):
+        super().create(n)
+
+        self.ax[-n:]       = 0.0
+        self.az[-n:]       = 0.0
+        self.swhdgsel[-n:] = False
+        self.swaltsel[-n:] = False
+
+    def update(self):
+        """ Perform one kinematic integration step for all aircraft. """
+        self.update_airspeed()
+        self.update_groundspeed()
+        self.update_pos()
+
+    def update_airspeed(self):
+        traf = bs.traf
+        # Compute horizontal acceleration
+        delta_spd = traf.aporasas.tas - traf.tas
+        need_ax = np.abs(delta_spd) > np.abs(bs.sim.simdt * traf.perf.axmax)
+        self.ax = need_ax * np.sign(delta_spd) * traf.perf.axmax
+        # Update velocities
+        traf.tas = np.where(need_ax, traf.tas + self.ax * bs.sim.simdt, traf.aporasas.tas)
+        traf.cas = vtas2cas(traf.tas, traf.alt)
+        traf.M = vtas2mach(traf.tas, traf.alt)
+
+        # Turning bank triangle
+        # tan phi = a centrigugal/a grav = omega^2 * R / g = omega * V /g
+        # => omega = (g tan phi)/V
+        turnrate = np.degrees(g0 * np.tan(np.where(traf.ap.turnphi > traf.eps * traf.eps,
+                                                   traf.ap.turnphi, traf.ap.bankdef) )
+                                          / np.maximum(traf.tas, traf.eps))
+        delhdg = (traf.aporasas.hdg - traf.hdg + 180) % 360 - 180  # [deg]
+        self.swhdgsel = np.abs(delhdg) > np.abs(bs.sim.simdt * turnrate)
+
+        # Update heading
+        traf.hdg = np.where(self.swhdgsel,
+                            traf.hdg + bs.sim.simdt * turnrate * np.sign(delhdg), traf.aporasas.hdg) % 360.0
+
+        # Update vertical speed (alt select, capture and hold autopilot mode)
+        delta_alt = traf.aporasas.alt - traf.alt
+        # Old dead band version:
+        #        self.swaltsel = np.abs(delta_alt) > np.maximum(
+        #            10 * ft, np.abs(2 * bs.sim.simdt * traf.vs))
+
+        # Update version: time based engage of altitude capture (to adapt for UAV vs airliner scale)
+        self.swaltsel = np.abs(delta_alt) > 1.05 * np.maximum(np.abs(bs.sim.simdt * traf.aporasas.vs),
+                                                         np.abs(bs.sim.simdt * traf.vs))
+        target_vs = self.swaltsel * np.sign(delta_alt) * np.abs(traf.aporasas.vs)
+        delta_vs = target_vs - traf.vs
+        # print(delta_vs / fpm)
+        need_az = np.abs(delta_vs) > 300 * fpm   # small threshold
+        self.az = need_az * np.sign(delta_vs) * (300 * fpm)   # fixed vertical acc approx 1.6 m/s^2
+        traf.vs = np.where(need_az, traf.vs + self.az * bs.sim.simdt, target_vs)
+        traf.vs = np.where(np.isfinite(traf.vs), traf.vs, 0)    # fix vs nan issue
+
+    def update_groundspeed(self):
+        traf = bs.traf
+        # Compute ground speed and track from heading, airspeed and wind
+        if traf.wind.winddim == 0:  # no wind
+            traf.gsnorth  = traf.tas * np.cos(np.radians(traf.hdg))
+            traf.gseast   = traf.tas * np.sin(np.radians(traf.hdg))
+
+            traf.gs  = traf.tas
+            traf.trk = traf.hdg
+            traf.windnorth[:], traf.windeast[:] = 0.0, 0.0
+
+        else:
+            applywind = traf.alt > 50. * ft  # Only apply wind when airborne
+
+            vnwnd, vewnd = traf.wind.getdata(traf.lat, traf.lon, traf.alt)
+            traf.windnorth[:], traf.windeast[:] = vnwnd, vewnd
+            traf.gsnorth  = traf.tas * np.cos(np.radians(traf.hdg)) + traf.windnorth * applywind
+            traf.gseast   = traf.tas * np.sin(np.radians(traf.hdg)) + traf.windeast * applywind
+
+            traf.gs  = np.logical_not(applywind) * traf.tas + \
+                       applywind * np.sqrt(traf.gsnorth**2 + traf.gseast**2)
+
+            traf.trk = np.logical_not(applywind) * traf.hdg + \
+                       applywind * np.degrees(np.arctan2(traf.gseast, traf.gsnorth)) % 360.
+
+        traf.work += (traf.perf.thrust * bs.sim.simdt * np.sqrt(traf.gs * traf.gs + traf.vs * traf.vs))
+
+    def update_pos(self):
+        traf = bs.traf
+        # Update position
+        traf.alt = np.where(self.swaltsel, np.round(traf.alt + traf.vs * bs.sim.simdt, 6), traf.aporasas.alt)
+        traf.lat = traf.lat + np.degrees(bs.sim.simdt * traf.gsnorth / Rearth)
+        traf.coslat = np.cos(np.deg2rad(traf.lat))
+        traf.lon = traf.lon + np.degrees(bs.sim.simdt * traf.gseast / traf.coslat / Rearth)
+        traf.distflown += traf.gs * bs.sim.simdt

--- a/bluesky/traffic/performance/bada/perfbada.py
+++ b/bluesky/traffic/performance/bada/perfbada.py
@@ -333,7 +333,7 @@ class BADA(PerfBase):
         # flight phase
         self.phase, self.bank = phases(bs.traf.alt, bs.traf.gs, delalt,
             bs.traf.cas, self.vmto, self.vmic, self.vmap, self.vmcr, self.vmld,
-            bs.traf.ap.bankdef, bs.traf.bphase, bs.traf.swhdgsel, swbada)
+            bs.traf.ap.bankdef, bs.traf.bphase, bs.traf.kinematics.swhdgsel, swbada)
 
         # AERODYNAMICS
         # Lift

--- a/bluesky/traffic/performance/legacy/perfbs.py
+++ b/bluesky/traffic/performance/legacy/perfbs.py
@@ -197,7 +197,7 @@ class Legacy(PerfBase):
         # allocate aircraft to their flight phase
         self.phase, self.bank = phases(bs.traf.alt, bs.traf.gs, delalt,
             bs.traf.cas, self.vmto, self.vmic, self.vmap, self.vmcr, self.vmld,
-            bs.traf.ap.bankdef, bs.traf.bphase, bs.traf.swhdgsel,swbada)
+            bs.traf.ap.bankdef, bs.traf.bphase, bs.traf.kinematics.swhdgsel,swbada)
 
         # AERODYNAMICS
         # compute CL: CL = 2*m*g/(VTAS^2*rho*S)

--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -223,7 +223,7 @@ class OpenAP(PerfBase):
 
         # ----- compute net thrust -----
         self.thrust[idx_fixwing] = (
-            self.drag[idx_fixwing] + self.mass[idx_fixwing] * bs.traf.ax[idx_fixwing]
+            self.drag[idx_fixwing] + self.mass[idx_fixwing] * bs.traf.kinematics.ax[idx_fixwing]
         )
 
         # ----- compute fuel flow -----

--- a/bluesky/traffic/traffic.py
+++ b/bluesky/traffic/traffic.py
@@ -9,8 +9,8 @@ from bluesky.core import Entity, Timer
 from bluesky.stack.recorder import savecmd
 from bluesky.tools import geo
 from bluesky.tools.misc import latlon2txt
-from bluesky.tools.aero import casormach2tas, fpm, kts, ft, g0, Rearth, nm, tas2cas,\
-                         vatmos,  vtas2cas, vtas2mach, vcasormach
+from bluesky.tools.aero import casormach2tas, kts, ft, nm, tas2cas,\
+                         vatmos, vcasormach
 
 
 from bluesky.traffic.asas import ConflictDetection, ConflictResolution, ResumeNavigation
@@ -24,6 +24,7 @@ from .activewpdata import ActiveWaypoint
 from .turbulence import Turbulence
 from .trafficgroups import TrafficGroups
 from .performance.perfbase import PerfBase
+from .kinematics import Kinematics
 
 # Register settings defaults
 bs.settings.set_variable_defaults(performance_model='openap', asas_dt=1.0)
@@ -103,9 +104,6 @@ class Traffic(Entity):
             self.M       = np.array([])  # mach number
             self.vs      = np.array([])  # vertical speed [m/s]
 
-            # Acceleration
-            self.ax = np.array([])  # [m/s2] current longitudinal acceleration
-
             # Atmosphere
             self.p       = np.array([])  # air pressure [N/m2]
             self.rho     = np.array([])  # air density [kg/m3]
@@ -137,12 +135,11 @@ class Traffic(Entity):
             self.trails   = Trails()
             self.actwp    = ActiveWaypoint()
             self.perf     = PerfBase()
+            self.kinematics = Kinematics()
 
             # Group Logic
             self.groups = TrafficGroups()
 
-            # Traffic autopilot data
-            self.swhdgsel = np.array([], dtype=bool)  # determines whether aircraft is turning
 
             # Traffic autothrottle settings
             self.swats    = np.array([], dtype=bool)  # Switch indicating whether autothrottle system is on/off
@@ -414,12 +411,10 @@ class Traffic(Entity):
         #---------- Limit commanded speeds based on performance ------------------------------
         self.aporasas.tas, self.aporasas.vs, self.aporasas.alt = \
             self.perf.limits(self.aporasas.tas, self.aporasas.vs,
-                             self.aporasas.alt, self.ax)
+                             self.aporasas.alt, self.kinematics.ax)
 
         #---------- Kinematics --------------------------------
-        self.update_airspeed()
-        self.update_groundspeed()
-        self.update_pos()
+        self.kinematics.update()
 
         #---------- Simulate Turbulence -----------------------
         self.turbulence.update()
@@ -429,81 +424,6 @@ class Traffic(Entity):
 
         #---------- Aftermath ---------------------------------
         self.trails.update()
-
-    def update_airspeed(self):
-        # Compute horizontal acceleration
-        delta_spd = self.aporasas.tas - self.tas
-        need_ax = np.abs(delta_spd) > np.abs(bs.sim.simdt * self.perf.axmax)
-        self.ax = need_ax * np.sign(delta_spd) * self.perf.axmax
-        # Update velocities
-        self.tas = np.where(need_ax, self.tas + self.ax * bs.sim.simdt, self.aporasas.tas)
-        self.cas = vtas2cas(self.tas, self.alt)
-        self.M = vtas2mach(self.tas, self.alt)
-
-        # Turning bank triangle
-        # tan phi = a centrigugal/a grav = omega^2 * R / g = omega * V /g
-        # => omega = (g tan phi)/V
-        turnrate = np.degrees(g0 * np.tan(np.where(self.ap.turnphi>self.eps*self.eps,
-                                                   self.ap.turnphi,self.ap.bankdef)) \
-                                          / np.maximum(self.tas, self.eps))
-        delhdg = (self.aporasas.hdg - self.hdg + 180) % 360 - 180  # [deg]
-        self.swhdgsel = np.abs(delhdg) > np.abs(bs.sim.simdt * turnrate)
-
-        # Update heading
-        self.hdg = np.where(self.swhdgsel, 
-                            self.hdg + bs.sim.simdt * turnrate * np.sign(delhdg), self.aporasas.hdg) % 360.0
-
-        # Update vertical speed (alt select, capture and hold autopilot mode)
-        delta_alt = self.aporasas.alt - self.alt
-        # Old dead band version:
-        #        self.swaltsel = np.abs(delta_alt) > np.maximum(
-        #            10 * ft, np.abs(2 * bs.sim.simdt * self.vs))
-
-        # Update version: time based engage of altitude capture (to adapt for UAV vs airliner scale)
-        self.swaltsel = np.abs(delta_alt) >  1.05*np.maximum(np.abs(bs.sim.simdt * self.aporasas.vs), \
-                                                         np.abs(bs.sim.simdt * self.vs))
-        target_vs = self.swaltsel * np.sign(delta_alt) * np.abs(self.aporasas.vs)
-        delta_vs = target_vs - self.vs
-        # print(delta_vs / fpm)
-        need_az = np.abs(delta_vs) > 300 * fpm   # small threshold
-        self.az = need_az * np.sign(delta_vs) * (300 * fpm)   # fixed vertical acc approx 1.6 m/s^2
-        self.vs = np.where(need_az, self.vs+self.az*bs.sim.simdt, target_vs)
-        self.vs = np.where(np.isfinite(self.vs), self.vs, 0)    # fix vs nan issue
-
-    def update_groundspeed(self):
-        # Compute ground speed and track from heading, airspeed and wind
-        if self.wind.winddim == 0:  # no wind
-            self.gsnorth  = self.tas * np.cos(np.radians(self.hdg))
-            self.gseast   = self.tas * np.sin(np.radians(self.hdg))
-
-            self.gs  = self.tas
-            self.trk = self.hdg
-            self.windnorth[:], self.windeast[:] = 0.0,0.0
-
-        else:
-            applywind = self.alt>50.*ft # Only apply wind when airborne
-
-            vnwnd,vewnd = self.wind.getdata(self.lat, self.lon, self.alt)
-            self.windnorth[:], self.windeast[:] = vnwnd,vewnd
-            self.gsnorth  = self.tas * np.cos(np.radians(self.hdg)) + self.windnorth*applywind
-            self.gseast   = self.tas * np.sin(np.radians(self.hdg)) + self.windeast*applywind
-
-            self.gs  = np.logical_not(applywind)*self.tas + \
-                       applywind*np.sqrt(self.gsnorth**2 + self.gseast**2)
-
-            self.trk = np.logical_not(applywind)*self.hdg + \
-                       applywind*np.degrees(np.arctan2(self.gseast, self.gsnorth)) % 360.
-
-        self.work += (self.perf.thrust * bs.sim.simdt * np.sqrt(self.gs * self.gs + self.vs * self.vs))
-
-
-    def update_pos(self):
-        # Update position
-        self.alt = np.where(self.swaltsel, np.round(self.alt + self.vs * bs.sim.simdt, 6), self.aporasas.alt)
-        self.lat = self.lat + np.degrees(bs.sim.simdt * self.gsnorth / Rearth)
-        self.coslat = np.cos(np.deg2rad(self.lat))
-        self.lon = self.lon + np.degrees(bs.sim.simdt * self.gseast / self.coslat / Rearth)
-        self.distflown += self.gs * bs.sim.simdt
 
     def id2idx(self, acid):
         """Find index of aircraft id"""


### PR DESCRIPTION
I got an idea to make the kinematics a replaceable class so that we can model slightly different physics for rotors. This idea was inspired from a chat with @fazlurnu.

The code moves the point-mass integration (`update_airspeed`, `update_groundspeed`, `update_pos`) out of `Traffic` into a new `bluesky/traffic/kinematics.py`, following the `Autopilot` pattern: a replaceable `Entity` created in `Traffic`'s `settrafarrays()` block with its own `create()` / `update()`.

## Reason
So the kinematics model can be swapped for an alternative implementation (e.g. from a plugin) via `Kinematics.select()`, instead of being hard-coded into `Traffic`. In this way you could create a new kinematics for drones.

## Details
- The class owns all four integration-produced variables, all initialised in
  `__init__`: `ax`, `az`, `swhdgsel`, `swaltsel`.
  - `ax` / `swhdgsel` moved off `Traffic`.
  - `az` / `swaltsel` were previously not declared as traffic arrays at all; they now resize correctly on create/delete/reset.
- Performance models and `Traffic.update` now read the relocated arrays via `bs.traf.kinematics.ax`/`bs.traf.kinematics.swhdgsel` (`perfoap`, `perfbs`, `perfbada`).