### PR TITLE
Add Free-to-revert (FTR) into the resume navigation

### DIFF
--- a/bluesky/traffic/asas/__init__.py
+++ b/bluesky/traffic/asas/__init__.py
@@ -4,3 +4,4 @@ from .resumenav import ResumeNavigation
 from .statebased import StateBased
 from .mvp import MVP
 from .pastcpa import PastCPA
+from .ftr import FTR

--- a/bluesky/traffic/asas/ftr.py
+++ b/bluesky/traffic/asas/ftr.py
@@ -1,0 +1,206 @@
+''' Resume navigation based on the Free-To-Revert (FTR) criterion. '''
+import numpy as np
+
+import bluesky as bs
+from bluesky.stack import command
+from bluesky.traffic.asas import ResumeNavigation
+
+
+class FTR(ResumeNavigation):
+    ''' Resume navigation using the Free-To-Revert method.
+
+        This is from Wouter Schaberg's Thesis
+        https://repository.tudelft.nl/record/uuid:529b6868-f0b4-49e3-94c3-82e52ebe0c7d
+
+        FTR resumes navigation by calculating whether the 'target' distance
+        at CPA is bigger than the protected zone. The word target there is used
+        because it is calculated from the desired velocity (from autopilot)
+        of ownship, against:
+
+        1. intruder's current velocity, criterion 1
+        2. intruder's desired velocity (from autopilot), criterion 2
+
+        However, typically aircraft don't share intent these days so the default
+        mode of criterion 2 is ASSUMED -> the desired velocity is equal to the 
+        velocit when the two aircraft first detected in conflict.
+
+        FTRINTENT OFF sets the criterion 2 to always TRUE, making it inactive
+        FTRINTENT DECLARED enables the criterion 2 to use the autopilot data of intruders
+    '''
+
+    def __init__(self):
+        super().__init__()
+        self.assumed = dict()
+
+        self.intent = 'ASSUMED'
+
+    def selectedmsg(self):
+        '''
+            Line RESNAV appends to its own confirmation, naming the FTRINTENT
+            method criterion 2 will use.
+        '''
+        return f'Selected {self.intent} as FTRINTENT method.'
+
+    def reset(self):
+        super().reset()
+        self.assumed.clear()
+        self.intent = 'ASSUMED'
+
+    def resumenav(self, conf, ownship, intruder):
+        '''
+            Decide for each aircraft in the conflict list whether the ASAS
+            should be followed or not, based on whether reverting to the
+            autopilot velocity would still clear the intruder.
+        '''
+        # Record the assumed intent on the tick a pair becomes active, before
+        # the pair is merged into resopairs, so it is the velocity the intruder
+        # was flying when this conflict was first detected.
+        for pair in conf.confpairs:
+            if pair not in self.resopairs:
+                idx2 = bs.traf.id2idx(pair[1])
+                if idx2 >= 0:
+                    self.assumed[pair] = (intruder.gseast[idx2], intruder.gsnorth[idx2])
+
+        # Add new conflicts to resopairs
+        self.resopairs.update(conf.confpairs)
+
+        # Conflict pairs to be deleted
+        delpairs = set()
+        changeactive = dict()
+
+        # Look at all conflicts, also the ones that are solved but for which
+        # reverting would not yet be safe
+        for conflict in self.resopairs:
+            idx1, idx2 = bs.traf.id2idx(conflict)
+            # If the ownship aircraft is deleted remove its conflict from the list
+            if idx1 < 0:
+                delpairs.add(conflict)
+                continue
+
+            if idx2 >= 0:
+                # Distance vector using flat earth approximation
+                re = 6371000.
+                dist = re * np.array([np.radians(intruder.lon[idx2] - ownship.lon[idx1]) *
+                                      np.cos(0.5 * np.radians(intruder.lat[idx2] +
+                                                              ownship.lat[idx1])),
+                                      np.radians(intruder.lat[idx2] - ownship.lat[idx1])])
+
+                rpz = np.max(conf.rpz[[idx1, idx2]])
+
+                # The ownship's own side of both criteria: its desired velocity,
+                # i.e. what the autopilot would fly the moment ASAS lets go.
+                vown = self.desired_spd_trk(ownship, idx1)
+
+                # Criterion 1: the intruder holds its current, observed velocity
+                vintr = np.array([intruder.gseast[idx2], intruder.gsnorth[idx2]])
+                ftr = self.clears(dist, vintr - vown, rpz)
+
+                # Criterion 2: the intruder reverts to its desired velocity too
+                if ftr and self.intent != 'OFF':
+                    if self.intent == 'ASSUMED':
+                        vrevert = self.assumed.get(conflict)
+                        vrevert = None if vrevert is None else np.array(vrevert)
+                    else:
+                        vrevert = self.desired_spd_trk(intruder, idx2)
+                    if vrevert is not None:
+                        ftr = self.clears(dist, vrevert - vown, rpz)
+
+            # Keep resolving for ownship while reverting would not clear the
+            # intruder. A pair still in horizontal LOS never clears: with the
+            # pair diverging the criterion falls back to the current distance,
+            # which is inside rpz by definition.
+            if idx2 >= 0 and not ftr:
+                # Enable ASAS for this aircraft
+                changeactive[idx1] = True
+            else:
+                # Switch ASAS off for ownship if there are no other conflicts
+                # that this aircraft is involved in.
+                changeactive[idx1] = changeactive.get(idx1, False)
+                # If reverting is safe, remove the pair from the resopairs list
+                delpairs.add(conflict)
+
+        for idx, active in changeactive.items():
+            # Loop a second time: this is to avoid that ASAS resolution is
+            # turned off for an aircraft that is involved simultaneously in
+            # multiple conflicts, where the first, but not all conflicts are
+            # resolved.
+            bs.traf.cr.active[idx] = active
+            if not active:
+                # Waypoint recovery after conflict: Find the next active waypoint
+                # and send the aircraft to that waypoint.
+                iwpid = bs.traf.ap.route[idx].findact(idx)
+                if iwpid != -1:  # To avoid problems if there are no waypoints
+                    bs.traf.ap.route[idx].direct(
+                        idx, bs.traf.ap.route[idx].wpname[iwpid])
+
+        # Remove pairs that are free to revert or have deleted aircraft
+        self.resopairs -= delpairs
+        for conflict in delpairs:
+            self.assumed.pop(conflict, None)
+
+    @staticmethod
+    def clears(dist, vrel, rpz):
+        '''
+            Whether relative motion (position dist, velocity vrel) keeps the
+            closest point of approach beyond rpz.
+
+            Uses the *forward* closest approach: a pair that is already
+            diverging (tcpa <= 0), or that has no relative motion, is judged by
+            where it is now, not by a hypothetical closest approach in the past.
+        '''
+        vrel2 = np.dot(vrel, vrel)
+        dist2 = np.dot(dist, dist)
+        if vrel2 < 1e-9:
+            return dist2 > rpz * rpz
+        tcpa = -np.dot(dist, vrel) / vrel2
+        if tcpa <= 0.0:
+            return dist2 > rpz * rpz
+        return max(0.0, dist2 - tcpa * tcpa * vrel2) > rpz * rpz
+
+    @staticmethod
+    def desired_spd_trk(traf, idx):
+        '''
+            Ground velocity [east, north] the autopilot of aircraft idx would
+            fly right now: its desired track at its desired airspeed, corrected
+            for wind.
+
+            ap.trk is a desired *ground track*, so the wind triangle is solved
+            for the ground speed that makes that track good at ap.tas. Without
+            wind this reduces exactly to ap.tas along ap.trk.
+        '''
+        trk = np.radians(traf.ap.trk[idx])
+        along = np.array([np.sin(trk), np.cos(trk)])
+        wind = np.array([traf.windeast[idx], traf.windnorth[idx]])
+        # Split the wind into a component along the desired track and one across
+        # it; the aircraft crabs to cancel the crosswind, what is left over
+        # plus the tailwind component is the ground speed.
+        wpar = np.dot(wind, along)
+        wperp = wind[0] * along[1] - wind[1] * along[0]
+        tas = traf.ap.tas[idx]
+        if abs(wperp) >= tas:
+            # Crosswind exceeds the airspeed: the track cannot be made good.
+            # Fall back to the current ground velocity.
+            return np.array([traf.gseast[idx], traf.gsnorth[idx]])
+        return (wpar + np.sqrt(tas * tas - wperp * wperp)) * along
+
+    @command(name='FTRINTENT')
+    def setintent(self, mode: 'txt' = ''):
+        '''
+            Select how FTR obtains the intruder's desired velocity for its
+            second (intent-based) criterion.
+
+            OFF:      skip the second criterion.
+            ASSUMED:  the velocity the intruder was flying when the conflict
+                      was first detected (inferred, no intent sharing needed).
+                      This is the default.
+            DECLARED: read the intruder's autopilot (perfect intent sharing).
+        '''
+        modes = ('OFF', 'ASSUMED', 'DECLARED')
+        if not mode:
+            return True, f'Current FTRINTENT method: {self.intent}' + \
+                         f'\nAvailable FTRINTENT methods: {", ".join(modes)}'
+        if mode.upper() not in modes:
+            return False, f'{mode} doesn\'t exist.\n' + \
+                          f'Available FTRINTENT methods: {", ".join(modes)}'
+        self.intent = mode.upper()
+        return True, self.selectedmsg()

--- a/bluesky/traffic/asas/resumenav.py
+++ b/bluesky/traffic/asas/resumenav.py
@@ -63,4 +63,6 @@ class ResumeNavigation(Entity, replaceable=True):
 
         # Select the requested method
         method.select()
-        return True, f'Selected {method.__name__} as resume navigation method.'
+        msg = f'Selected {method.__name__} as resume navigation method.'
+        selectedmsg = getattr(method.instance(), 'selectedmsg', None)
+        return True, f'{msg}\n{selectedmsg()}' if selectedmsg else msg

--- a/scenario/ASAS/RESNAV-FTR-2DEG.scn
+++ b/scenario/ASAS/RESNAV-FTR-2DEG.scn
@@ -1,0 +1,19 @@
+# RESNAV TEST
+# Test resume navigation with the Free-To-Revert (FTR) method
+# Two aircraft on a shallow angle (2 deg) conflict at FL300
+# Near-parallel tracks are the geometry PastCPA needs its bouncing guard for
+# FTR instead holds the resolution until reverting to the autopilot velocity
+# genuinely clears the intruder.
+
+00:00:00.00>PAN -0.9 119.8
+00:00:00.00>ASAS ON
+00:00:00.00>RESO MVP
+
+00:00:00.00>RESNAV FTR
+# FTRINTET can be OFF | ASSUMED | DECLARED
+# 00:00:00.00>FTRINTENT DECLARED
+
+00:00:00.00>CRE GA001 B737 -0.900000,119.800000 0 FL300 200
+00:00:00.00>CRECONFS GA002 B737 GA001 2 0 200 0 0 200
+
+00:00:00.00>ECHO Conflict between GA001 and GA002 - shallow angle (2 deg) at FL300


### PR DESCRIPTION
From Wouter Schaberg's thesis (https://repository.tudelft.nl/record/uuid:529b6868-f0b4-49e3-94c3-82e52ebe0c7d)

The key idea is to use the 'target' distance at CPA to decide whether an aircraft is safe to resume the navigation by comparing the ownship's desired velocity to:
1. intruder's current velocity, criterion 1
2. intruder's desired velocity, criterion 2

At shallow angle, there's no bouncing and the aircraft safely separate.

<img width="961" height="629" alt="image" src="https://github.com/user-attachments/assets/b35b04a8-6655-4f40-a972-b3f4b0e00cc2" />

PastCPA as a comparison, safely separate but the conflict bounces on/off 24 times in a shorter time horizon.

<img width="959" height="648" alt="image" src="https://github.com/user-attachments/assets/15b4ead3-3af3-4463-9010-9f9704da2475" />