### PR TITLE
Add missing nm conversion in RTA leg time

### DIFF
--- a/bluesky/traffic/route.py
+++ b/bluesky/traffic/route.py
@@ -1523,7 +1523,7 @@ class Route(Base):
                             # xtorta stays the same! This leg will not be available for RTA scheduling, so distance
                             # is not in xtorta. Therefore we need to subtract legtime to ignore this leg for the RTA
                             # scheduling
-                            legtime = self.wpdistto[i+1]/legtas
+                            legtime = self.wpdistto[i+1] * nm / legtas
                             torta = torta - legtime
                     else:
                         xtorta = 0.0


### PR DESCRIPTION
There is a small unit conversion bug in line 1525 of `Route()` https://github.com/TUDelft-CNS-ATM/bluesky/blob/346b6b0123dc768519927888d00e492b2973b7f1/bluesky/traffic/route.py#L1526

`wpdistto` is in nautical miles and `legtas` is in metres/second.

See below in line 1510 where `wpdisto` is converted to metres https://github.com/TUDelft-CNS-ATM/bluesky/blob/346b6b0123dc768519927888d00e492b2973b7f1/bluesky/traffic/route.py#L1510

bug was originally found by @abc8747