### PR TITLE
Fix OpenAP speed limits being evaluated at intended altitude

### DIFF
--- a/bluesky/traffic/performance/openap/perfoap.py
+++ b/bluesky/traffic/performance/openap/perfoap.py
@@ -273,13 +273,16 @@ class OpenAP(PerfBase):
         """
         allow_h = np.where(intent_h > self.hmax, self.hmax, intent_h)
 
-        intent_v_cas = aero.vtas2cas(intent_v_tas, allow_h)
+
+        # Speed envelope is evaluated at the current altitude, not the intended one.
+        h = bs.traf.alt
+        intent_v_cas = aero.vtas2cas(intent_v_tas, h)
         allow_v_cas = np.where((intent_v_cas < self.vmin), self.vmin, intent_v_cas)
         allow_v_cas = np.where(intent_v_cas > self.vmax, self.vmax, allow_v_cas)
-        allow_v_tas = aero.vcas2tas(allow_v_cas, allow_h)
+        allow_v_tas = aero.vcas2tas(allow_v_cas, h)
         allow_v_tas = np.where(
-            aero.vtas2mach(allow_v_tas, allow_h) > self.mmo,
-            aero.vmach2tas(self.mmo, allow_h),
+            aero.vtas2mach(allow_v_tas, h) > self.mmo,
+            aero.vmach2tas(self.mmo, h),
             allow_v_tas,
         )  # maximum cannot exceed MMO
 


### PR DESCRIPTION
Fixes #602

The fix is to use `bs.traf.alt` for all `allow_v_tas` and `allow_v_cas` in `limits()` of `perfoap.py`

You can see issue with the following scenario:

```
00:00:00.00>PAN ARTIP
00:00:00.00>TRAILS ON
00:00:00.00>DTMULT 15.0
00:00:00.00>CRE AF265,A321,EEL,224,FL260,300
00:00:00.00>ADDWPT AF265,EEL,,
00:00:00.00>ADDWPT AF265,NOVEN,,
00:00:00.00>ADDWPT AF265,ARTIP,FL100,250
00:00:00.00>AF265 LNAV ON
00:00:00.00>AF265 VNAV ON
```

In current code a speed limit is set at the height of FL260 with a height of FL100. This causes the aircraft to reduce speed during descent.

After the fix the aircraft follows the commanded speed during the descent.