### PR TITLE
Fix MVP

### DIFF
--- a/bluesky/traffic/asas/mvp.py
+++ b/bluesky/traffic/asas/mvp.py
@@ -252,18 +252,16 @@ class MVP(ConflictResolution):
         # altitude also resolves the conflict. Because asasalttemp is calculated using
         # the time to resolve, it may result in climbing or descending more than the selected
         # altitude.
-        asasalttemp = np.where(altCondition, vscapped * timesolveV + ownship.alt, ownship.selalt)
+        asasalttemp = vscapped * timesolveV + ownship.alt
 
         signdvs = np.sign(vscapped - ownship.ap.vs * np.sign(ownship.selalt - ownship.alt))
         signalt = np.sign(asasalttemp - ownship.selalt)
-        alt = np.where(np.logical_or(signdvs == 0, signdvs == signalt), asasalttemp, ownship.selalt)
-
-   
-        alt[altCondition] = asasalttemp[altCondition]
+        alt = np.select([altCondition, np.logical_or(signdvs == 0, signdvs == signalt)],
+                        [asasalttemp, ownship.selalt], default=ownship.selalt)
 
         # If resolutions are limited in the horizontal direction, then asasalt should
         # be equal to auto pilot alt (aalt). This is to prevent a new asasalt being computed
-        # using the auto pilot vertical speed (ownship.avs) using the code in line 106 (asasalttemp) when only
+        # using the auto pilot vertical speed (ownship.avs) using the code above (altsolveV) when only
         # horizontal resolutions are allowed.
         alt = alt * (1 - self.swresohoriz) + ownship.selalt * self.swresohoriz
         return newtrack, newgscapped, vscapped, alt

--- a/bluesky/traffic/asas/mvp.py
+++ b/bluesky/traffic/asas/mvp.py
@@ -241,20 +241,24 @@ class MVP(ConflictResolution):
         # Cap the vertical speed
         vscapped = np.maximum(ownship.perf.vsmin,np.minimum(ownship.perf.vsmax,newvs))
 
+        
+        # To compute asas alt, timesolveV is used. timesolveV is a really big value (1e9)
+        # when there is no conflict. Therefore asas alt is only updated when its
+        # value is less than the look-ahead time, because for those aircraft are in conflict
+        altCondition = np.logical_and(timesolveV<conf.dtlookahead, np.abs(dv[2,:])>0.0)
+
         # Calculate if Autopilot selected altitude should be followed. This avoids ASAS from
         # climbing or descending longer than it needs to if the autopilot leveloff
         # altitude also resolves the conflict. Because asasalttemp is calculated using
         # the time to resolve, it may result in climbing or descending more than the selected
         # altitude.
-        asasalttemp = vscapped * timesolveV + ownship.alt
+        asasalttemp = np.where(altCondition, vscapped * timesolveV + ownship.alt, ownship.selalt)
+
         signdvs = np.sign(vscapped - ownship.ap.vs * np.sign(ownship.selalt - ownship.alt))
         signalt = np.sign(asasalttemp - ownship.selalt)
         alt = np.where(np.logical_or(signdvs == 0, signdvs == signalt), asasalttemp, ownship.selalt)
 
-        # To compute asas alt, timesolveV is used. timesolveV is a really big value (1e9)
-        # when there is no conflict. Therefore asas alt is only updated when its
-        # value is less than the look-ahead time, because for those aircraft are in conflict
-        altCondition = np.logical_and(timesolveV<conf.dtlookahead, np.abs(dv[2,:])>0.0)
+   
         alt[altCondition] = asasalttemp[altCondition]
 
         # If resolutions are limited in the horizontal direction, then asasalt should
@@ -331,8 +335,11 @@ class MVP(ConflictResolution):
 
         # Compute the resolution velocity vector in the vertical direction
         # The direction of the vertical resolution is such that the aircraft with
-        # higher climb/decent rate reduces their climb/decent rate
-        dv3 = np.where(abs(vrel[2]) > 0.0, (iV / tsolV) * (-vrel[2] / abs(vrel[2])), (iV / tsolV))
+        # higher climb/decent rate reduces their climb/decent rate. It must be
+        # antisymmetric between the two aircraft of a pair, otherwise a  
+        # pair manoeuvres the same way and never separates
+        dirV = np.where(abs(drel[2]) > 0.0, drel[2] / abs(drel[2]), np.sign(idx1 - idx2))
+        dv3 = np.where(abs(vrel[2]) > 0.0, (iV / tsolV) * (-vrel[2] / abs(vrel[2])), (iV / tsolV) * dirV)
 
         # It is necessary to cap dv3 to prevent that a vertical conflict
         # is solved in 1 timestep, leading to a vertical separation that is too

--- a/bluesky/traffic/asas/mvp.py
+++ b/bluesky/traffic/asas/mvp.py
@@ -261,7 +261,7 @@ class MVP(ConflictResolution):
 
         # If resolutions are limited in the horizontal direction, then asasalt should
         # be equal to auto pilot alt (aalt). This is to prevent a new asasalt being computed
-        # using the auto pilot vertical speed (ownship.avs) using the code above (altsolveV) when only
+        # using the auto pilot vertical speed (ownship.avs) using the code above (asasalttemp) when only
         # horizontal resolutions are allowed.
         alt = alt * (1 - self.swresohoriz) + ownship.selalt * self.swresohoriz
         return newtrack, newgscapped, vscapped, alt


### PR DESCRIPTION
# Description
In some cases MVP would lead aircraft to end up with zero ground speed while still airborne at a non-zero altitude.

See #660 


# Fix
This fixes two separate issues in the vertical resolution logic in `mvp.py`.
1. In `resolve()`, `timesolveV` is originally given a "really big value" `1e9` and is only updated for aircraft in `conf.confpairs`. However, `asasalttemp` was calculated for every aircraft, so aircraft outside the conflict list could end up with an altitude based on `vs * 1e9`.
2. The vertical resolution direction comes from `-vrel[2] / abs(vrel[2])`. When `vrel[2] == 0`, the original code gave both aircraft in a pair the same direction, so they could climb or descend together instead of separating.

# Verification
Run this scenario proposed in #660 and observe that the issue is resolved. The infringing aircraft was originally `AC5`.
```
# ---------------------------------------------------------------------------
# MVP horizontal+vertical resolution bug: 4-way co-altitude intersection
# ---------------------------------------------------------------------------

00:00:00.00>PAN 52.0,4.0
00:00:00.00>ZOOM 0.25
00:00:00.00>TRAILS ON

# --- CD/CR setup ---
00:00:00.00>CDMETHOD STATEBASED
00:00:00.00>RESO MVP
00:00:00.00>ZONER 5
00:00:00.00>ZONEDH 1000
00:00:00.00>DTLOOK 300

# RMETHH OFF clears swresohoriz, and swresovert is already False, turning on
# its combined horizontal+vertical resolution.
# RMETHV ON reproduces it as well (vertical-only resolution).
# Swap in "RMETHH BOTH" instead to see the bug disappear
00:00:00.00>RMETHH OFF

# --- 4-way co-altitude intersection over 52N 004E, all level at 2000 ft ---
00:00:00.00>CRE AC1,A320,52.5,4.0,180,2000,250
00:00:00.00>CRE AC2,A320,51.5,4.0,000,2000,250
00:00:00.00>CRE AC3,A320,52.0,4.8,270,2000,250
00:00:00.00>CRE AC4,A320,52.0,3.2,090,2000,250
00:00:00.00>CRE AC5,A320,52.7,4.0,180,2000,250
00:00:00.00>CRE AC6,A320,51.3,4.0,000,2000,250
00:00:00.00>CRE AC7,A320,52.0,5.1,270,2000,250
00:00:00.00>CRE AC8,A320,52.0,2.9,090,2000,250

00:00:00.00>ASAS ON
00:00:00.00>DTMULT 20
00:00:00.00>OP
```